### PR TITLE
removed text from Item view in popular recyclerView. just showing poster

### DIFF
--- a/app/src/main/res/layout/item_movie_card.xml
+++ b/app/src/main/res/layout/item_movie_card.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?><!-- res/layout/item_movie_card.xml -->
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
 
     <data>
+
         <variable
             name="movie"
             type="com.example.movie_project.models.MovieModel" />
+
         <variable
             name="clickListener"
             type="com.example.movie_project.views.MovieClickListener" />
@@ -33,34 +34,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:adjustViewBounds="true"
-                android:scaleType="fitXY"
                 android:imageUrl="@{movie.poster_path}"
+                android:scaleType="fitXY"
                 android:src="@drawable/placeholder2" />
-
-            <TextView
-                android:id="@+id/titleTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="8dp"
-                android:fontFamily="@font/montserrat_bold"
-                android:text="@{movie.title}"
-                android:textAppearance="@style/title"
-                android:textColor="@color/dark_grey"
-                android:textSize="16sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/releaseDateTextView"
-                android:fontFamily="@font/montserrat_italics"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="8dp"
-                android:paddingEnd="8dp"
-                android:paddingBottom="8dp"
-                android:text="@{movie.release_date}"
-                android:textColor="@color/dark_grey"
-                android:textSize="14sp" />
-
 
         </LinearLayout>
 


### PR DESCRIPTION
Changed itemView layout of recyclerview by removing text that show movie title and release date. that information is still available in the Movie Details view

### **Before**
<img width="456" height="910" alt="before_Itemview" src="https://github.com/user-attachments/assets/6d88eccf-4418-4676-acb3-a859fab98b27" />


### **After**

<img width="493" height="906" alt="After_itemview" src="https://github.com/user-attachments/assets/0bccaff3-37d2-40a2-b460-71d73c9f310a" />
