### PR TITLE
update deppendancies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace 'com.example.movie_project'
-    compileSdk 34
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.example.movie_project"
@@ -58,42 +58,42 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.core:core-ktx:1.18.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     //material 3
 //    implementation("androidx.compose.material3:material3-android:1.2.0-alpha06")
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 
     // Google Sign In SDK
-    implementation("com.google.android.gms:play-services-auth:20.6.0")
+    implementation("com.google.android.gms:play-services-auth:21.5.1")
 
     // Firebase SDK
-    implementation(platform("com.google.firebase:firebase-bom:32.2.2"))
-    implementation("com.google.firebase:firebase-analytics-ktx")
-    implementation("com.google.firebase:firebase-database-ktx:20.0.0")
-    implementation("com.google.firebase:firebase-storage-ktx")
-    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation(platform("com.google.firebase:firebase-bom:34.11.0"))
+    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-database")
+    implementation("com.google.firebase:firebase-storage")
+    implementation("com.google.firebase:firebase-auth")
     //firestore
     //implementation ('com.google.firebase:firebase-firestore:23.0.3')
 
     // Firebase UI Library
-    implementation("com.firebaseui:firebase-ui-auth:8.0.2")
-    implementation("com.firebaseui:firebase-ui-database:8.0.2")
+    implementation("com.firebaseui:firebase-ui-auth:9.1.1")
+    implementation("com.firebaseui:firebase-ui-database:9.1.1")
 
     // Retrofit
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.retrofit2:retrofit:3.0.0'
+    implementation 'com.squareup.retrofit2:converter-gson:3.0.0'
 
     // Navigation
-    implementation "androidx.navigation:navigation-fragment-ktx:2.7.1"
-    implementation "androidx.navigation:navigation-ui-ktx:2.7.1"
+    implementation "androidx.navigation:navigation-fragment-ktx:2.9.7"
+    implementation "androidx.navigation:navigation-ui-ktx:2.9.7"
 
     //Glide
-    implementation 'com.github.bumptech.glide:glide:4.15.1'
+    implementation 'com.github.bumptech.glide:glide:5.0.5'
     //Material Design
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.13.0'
 }

--- a/app/src/main/java/com/example/movie_project/SignUpActivity.kt
+++ b/app/src/main/java/com/example/movie_project/SignUpActivity.kt
@@ -17,7 +17,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
-import com.google.firebase.ktx.Firebase
+
 
 class SignUpActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySignUpBinding

--- a/app/src/main/java/com/example/movie_project/views/MessageAdapter.kt
+++ b/app/src/main/java/com/example/movie_project/views/MessageAdapter.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.example.movie_project.R
 import com.example.movie_project.models.MessageModel
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.ktx.Firebase
+
 
 class MessageAdapter(val context: Context, val messageList: ArrayList<MessageModel>) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {

--- a/app/src/main/java/com/example/movie_project/views/SearchViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/SearchViewModel.kt
@@ -16,6 +16,8 @@ import com.example.movie_project.networking.ApiUtil.apiService
 import com.example.movie_project.util.ApiKeyProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.util.Locale
+import java.util.Locale.getDefault
 
 class SearchViewModel : ViewModel() {
     private val _searchMovies = MutableLiveData<List<MovieModel>>()
@@ -52,7 +54,7 @@ class SearchViewModel : ViewModel() {
     fun filterList(text: String) {
         val filteredList = ArrayList<MovieModel>()
         for (item in searchMovies.value!!) {
-            if (item.title?.toLowerCase()?.contains(text.toLowerCase()) == true) {
+            if (item.title?.lowercase(getDefault())?.contains(text.lowercase(getDefault())) == true) {
                 filteredList.add(item)
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
     dependencies {
         classpath 'com.google.gms:google-services:4.4.4'
-        classpath 'com.android.tools.build:gradle:8.1.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20'
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.7"
+        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.9.7"
         //classpath 'com.android.tools.build:gradle:3.3.0-alpha05'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.0' apply false
-    id 'com.android.library' version '8.1.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
+    id 'com.android.application' version '8.13.2' apply false
+    id 'com.android.library' version '8.13.2' apply false
+    id 'org.jetbrains.kotlin.android' version '2.3.20' apply false
 
     // The google-services plugin is required to parse the google-services.json file
     id("com.google.gms.google-services") version "4.4.4" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
1. Firebase `-ktx` dependencies removed the `-ktx` suffix from `firebase-analytics`, `firebase-database`, `firebase-storage`, and `firebase-auth` since those separate KTX artifacts were removed in newer Firebase BOM versions.

2. `compileSdk` bump updated from 34 to 36 to satisfy `androidx.core:core-ktx:1.18.0`'s requirement.

3. Kotlin version upgrade updated from 1.8.20 to 2.2.0 (both classpath and plugins block) to match the `kotlin-stdlib 2.2.0` pulled in by dependencies.

4. Navigation safe-args plugin bumped from 2.7.7 to 2.9.7 to match the navigation libraries.
