### PR TITLE
Add viewModel Error and Loading states, also add progressbar to Fragm…

### DIFF
--- a/app/src/main/java/com/example/movie_project/views/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/FavoritesViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.movie_project.views
 
 import android.util.Log
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.movie_project.models.MovieModel
@@ -14,6 +15,12 @@ import com.google.firebase.database.ValueEventListener
 class FavoritesViewModel : ViewModel() {
     private val _favorites = MutableLiveData<List<MovieModel>>()
     val favorites: MutableLiveData<List<MovieModel>> = _favorites
+
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> = _errorMessage
+
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
     
     // Store reference to database and listener for proper cleanup
     private var favDatabaseReference: DatabaseReference? = null
@@ -21,11 +28,16 @@ class FavoritesViewModel : ViewModel() {
 
 
      fun fetchFavorites() {
+        _errorMessage.postValue(null)
+        _isLoading.postValue(true)
+
         // Get current user ID and check if user is authenticated
         val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
         
         if (currentUserId == null) {
             Log.e("FavoritesViewModel", "User not authenticated")
+            _errorMessage.postValue("Please sign in to view favorites")
+            _isLoading.postValue(false)
             _favorites.postValue(emptyList())
             return
         }
@@ -52,10 +64,13 @@ class FavoritesViewModel : ViewModel() {
                 }
                 
                 _favorites.postValue(favoriteMoviesList)
+                _isLoading.postValue(false)
             }
 
             override fun onCancelled(error: DatabaseError) {
                 Log.e("FavoritesViewModel", "Error: ${error.message}")
+                _errorMessage.postValue(error.message)
+                _isLoading.postValue(false)
                 _favorites.postValue(emptyList())
             }
         }

--- a/app/src/main/java/com/example/movie_project/views/HomeViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/HomeViewModel.kt
@@ -17,6 +17,12 @@ class HomeViewModel : ViewModel() {
     private val _movies = MutableLiveData<List<MovieModel>>()
     val movies: LiveData<List<MovieModel>> = _movies
 
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> = _errorMessage
+
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
+
     private val apiService = ApiUtil.apiService
 
     init {
@@ -25,17 +31,24 @@ class HomeViewModel : ViewModel() {
 
     fun fetchMovies() {
         viewModelScope.launch(Dispatchers.IO) {
+            _errorMessage.postValue(null)
+            _isLoading.postValue(true)
             try {
                 val response = apiService.getPopularMovies(ApiKeyProvider.getApiKey())
                 if (response.isSuccessful) {
                     _movies.postValue(response.body()?.results)
                     Log.i("HomeViewModel", "Success: ${response.body()?.results}")
+                } else {
+                    _errorMessage.postValue("Failed to load movies")
+                    Log.e("HomeViewModel", "Unsuccessful response: ${response.code()}")
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
+                _errorMessage.postValue(e.localizedMessage ?: "An unexpected error occurred")
                 Log.e("HomeViewModel", "Error: ${e.message}")
+            } finally {
+                _isLoading.postValue(false)
             }
-
         }
     }
 

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailViewModel.kt
@@ -1,8 +1,10 @@
 package com.example.movie_project.views.movielog
 
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.movie_project.data.local.MovieLogDatabase
 import com.example.movie_project.data.local.MovieLogEntry
@@ -16,6 +18,9 @@ import kotlinx.coroutines.launch
 class MovieLogDetailViewModel(application: Application) : AndroidViewModel(application) {
 
     private val repository: MovieLogRepository
+
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> = _errorMessage
 
     init {
         val dao = MovieLogDatabase.getDatabase(application).movieLogDao()
@@ -36,8 +41,13 @@ class MovieLogDetailViewModel(application: Application) : AndroidViewModel(appli
      */
     fun insertEntry(entry: MovieLogEntry, onComplete: () -> Unit) {
         viewModelScope.launch {
-            repository.insertEntry(entry)
-            onComplete()
+            try {
+                repository.insertEntry(entry)
+                onComplete()
+            } catch (e: Exception) {
+                Log.e("MovieLogDetailVM", "Insert failed: ${e.message}")
+                _errorMessage.postValue(e.localizedMessage ?: "Failed to save movie log entry")
+            }
         }
     }
 
@@ -48,8 +58,13 @@ class MovieLogDetailViewModel(application: Application) : AndroidViewModel(appli
      */
     fun updateEntry(entry: MovieLogEntry, onComplete: () -> Unit) {
         viewModelScope.launch {
-            repository.updateEntry(entry)
-            onComplete()
+            try {
+                repository.updateEntry(entry)
+                onComplete()
+            } catch (e: Exception) {
+                Log.e("MovieLogDetailVM", "Update failed: ${e.message}")
+                _errorMessage.postValue(e.localizedMessage ?: "Failed to update movie log entry")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogViewModel.kt
@@ -3,6 +3,7 @@ package com.example.movie_project.views.movielog
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.example.movie_project.data.local.MovieLogDatabase
 import com.example.movie_project.data.local.MovieLogEntry
 import com.example.movie_project.data.repository.MovieLogRepository
@@ -14,6 +15,9 @@ import com.example.movie_project.data.repository.MovieLogRepository
 class MovieLogViewModel(application: Application) : AndroidViewModel(application) {
 
     private val repository: MovieLogRepository
+
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> = _errorMessage
 
     val allEntries: LiveData<List<MovieLogEntry>>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -65,6 +65,16 @@
             app:layout_constraintTop_toBottomOf="@+id/toolbar_home_activity"
             app:spanCount="2"
             tools:listitem="@layout/item_movie_card" />
+
+        <ProgressBar
+            android:id="@+id/homeProgressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbar_home_activity" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>


### PR DESCRIPTION
…ent_home.xml

1. HomeViewModel.kt

 - Add _errorMessage / errorMessage and _isLoading / isLoading LiveData
 - In fetchMovies(): clear error at start, set loading true, handle !response.isSuccessful with error message, catch block posts to _errorMessage, finally sets loading
  false

 2. FavoritesViewModel.kt

 - Add _errorMessage / errorMessage and _isLoading / isLoading LiveData
 - In fetchFavorites(): clear error, set loading true, post error if currentUserId == null, post loading false in onDataChange and onCancelled, post error message in
 onCancelled

 3. MovieLogDetailViewModel.kt

 - Add _errorMessage / errorMessage LiveData
 - Wrap repository.insertEntry() and repository.updateEntry() in try/catch, post errors on failure, only call onComplete on success

 4. MovieLogViewModel.kt

 - Add _errorMessage / errorMessage LiveData for consistency (read path via Room LiveData is already safe)
 
 5. fragment_home.xml — Add ProgressBar (id: homeProgressBar), centered, visibility gone