### PR TITLE
Add retry interceptor

### DIFF
--- a/app/src/main/java/com/example/movie_project/networking/ApiUtil.kt
+++ b/app/src/main/java/com/example/movie_project/networking/ApiUtil.kt
@@ -1,13 +1,19 @@
 package com.example.movie_project.networking
 
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object ApiUtil {
     const val BASE_URL = "https://api.themoviedb.org/3/"
 
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(RetryInterceptor())
+        .build()
+
     private val retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
+        .client(okHttpClient)
         .addConverterFactory(GsonConverterFactory.create())
         .build()
 

--- a/app/src/main/java/com/example/movie_project/networking/RetryInterceptor.kt
+++ b/app/src/main/java/com/example/movie_project/networking/RetryInterceptor.kt
@@ -1,0 +1,69 @@
+package com.example.movie_project.networking
+
+import android.util.Log
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+/**
+ * OkHttp Interceptor that retries failed network requests.
+ * Retries on both network failures (IOException) and HTTP error responses (non-2xx).
+ *
+ * @param maxRetries Maximum number of total attempts (default: 3)
+ * @param retryDelayMillis Delay in milliseconds between retries (default: 3000ms)
+ */
+class RetryInterceptor(
+    private val maxRetries: Int = 3,
+    private val retryDelayMillis: Long = 3000L
+) : Interceptor {
+
+    companion object {
+        private const val TAG = "RetryInterceptor"
+    }
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        var lastException: IOException? = null
+        var response: Response? = null
+
+        for (attempt in 1..maxRetries) {
+            try {
+                // Close previous unsuccessful response before retrying
+                response?.close()
+
+                response = chain.proceed(request)
+
+                // If the response is successful, return immediately
+                if (response.isSuccessful) {
+                    return response
+                }
+
+                // HTTP error response — log and retry if attempts remain
+                Log.w(TAG, "Attempt $attempt/$maxRetries failed with HTTP ${response.code}")
+
+                if (attempt == maxRetries) {
+                    // Final attempt — return the error response as-is
+                    return response
+                }
+
+                // Wait before retrying
+                Thread.sleep(retryDelayMillis)
+
+            } catch (e: IOException) {
+                lastException = e
+                Log.w(TAG, "Attempt $attempt/$maxRetries failed with exception: ${e.message}")
+
+                if (attempt == maxRetries) {
+                    throw lastException
+                }
+
+                // Wait before retrying
+                Thread.sleep(retryDelayMillis)
+            }
+        }
+
+        // This should never be reached, but satisfies the compiler
+        throw lastException ?: IOException("Unknown error after $maxRetries retries")
+    }
+}


### PR DESCRIPTION
Both steps are complete. Here's a summary of what was implemented:

**1. Created `RetryInterceptor.kt`** (`app/src/main/java/com/example/movie_project/networking/RetryInterceptor.kt`)
- OkHttp `Interceptor` that retries up to 3 attempts with a 3-second delay between each
- Retries on **network failures** (IOException) — catches the exception, waits, retries, and throws on final failure
- Retries on **HTTP error responses** (non-2xx) — closes the response, waits, retries, and returns the error response on final failure
- Configurable via constructor params (`maxRetries`, `retryDelayMillis`) for testability
- Logs each retry attempt via `Log.w`

**2. Updated `ApiUtil.kt`** — added an `OkHttpClient` with the `RetryInterceptor` and passed it to `Retrofit.Builder().client()`

No changes were needed to `HomeViewModel`, `SearchViewModel`, `MovieService`, or any other files. All API calls going through `ApiUtil.apiService` now automatically get retry behavior.