### PR TITLE
Splash activity to compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,10 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    // Compose UI testing
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.10.01')
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
     // Room in-memory database for instrumented tests
     androidTestImplementation "androidx.room:room-testing:$room_version"
     // Arch core testing for LiveData in instrumented tests

--- a/app/src/androidTest/java/com/example/movie_project/views/splash/SplashScreenTest.kt
+++ b/app/src/androidTest/java/com/example/movie_project/views/splash/SplashScreenTest.kt
@@ -1,0 +1,47 @@
+package com.example.movie_project.views.splash
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SplashScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun splashScreen_displaysLogo() {
+        composeTestRule.setContent {
+            SplashScreen(onTimeout = {}, splashDurationMs = 5_000L)
+        }
+        composeTestRule.onNodeWithContentDescription("Movie Magic logo")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun splashScreen_callsOnTimeoutAfterDelay() {
+        var called = false
+        composeTestRule.setContent {
+            SplashScreen(onTimeout = { called = true }, splashDurationMs = 100L)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 2_000L) { called }
+        assertTrue("onTimeout should have been called after the delay", called)
+    }
+
+    @Test
+    fun splashScreen_doesNotCallOnTimeoutImmediately() {
+        var called = false
+        composeTestRule.setContent {
+            SplashScreen(onTimeout = { called = true }, splashDurationMs = 5_000L)
+        }
+        // Right after composition, the callback should not have fired yet
+        assertFalse("onTimeout should not be called immediately", called)
+    }
+}


### PR DESCRIPTION
Created `SplashScreenTest.kt` at `app/src/androidTest/java/com/example/movie_project/views/splash/` with three instrumented tests:

1. **`splashScreen_displaysLogo`** — Verifies the Movie Magic logo image is displayed
2. **`splashScreen_callsOnTimeoutAfterDelay`** — Verifies `onTimeout` callback fires after the splash duration (uses 100ms for fast test execution)
3. **`splashScreen_doesNotCallOnTimeoutImmediately`** — Verifies the callback isn't invoked right after composition

Also added the required Compose UI test dependencies to `app/build.gradle`:
- `androidx.compose.ui:ui-test-junit4` (androidTest)
- `androidx.compose.ui:ui-test-manifest` (debug)
