### PR TITLE
Splash activity to compose

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
             android:name=".SignUpActivity"
             android:exported="true" />
         <activity
-            android:name=".SplashActivity"
+            android:name=".Splash_Activity"
             android:exported="true"
             android:theme="@style/AppTheme">
             <intent-filter>


### PR DESCRIPTION
Fixed the crash by updating `app/src/main/AndroidManifest.xml` line 41: changed `.SplashActivity` to `.Splash_Activity` to match the actual class name defined in `Splash_Activity.kt`. The app was crashing with `ClassNotFoundException` because the manifest referenced a class name without the underscore, but the Kotlin class is named `Splash_Activity` (with underscore). 