### PR TITLE
Movie log firebase intergration

### DIFF
--- a/app/src/main/java/com/example/movie_project/MovieMagicApp.kt
+++ b/app/src/main/java/com/example/movie_project/MovieMagicApp.kt
@@ -4,7 +4,9 @@ import android.app.Application
 import android.util.Log
 import com.example.movie_project.data.local.AppDatabase
 import com.example.movie_project.data.repository.FavoritesRepository
+import com.example.movie_project.data.repository.MovieLogRepository
 import com.example.movie_project.data.sync.FavoritesSyncManager
+import com.example.movie_project.data.sync.MovieLogSyncManager
 import com.example.movie_project.util.NetworkMonitor
 import com.google.firebase.FirebaseApp
 import com.google.firebase.database.FirebaseDatabase
@@ -15,6 +17,8 @@ import com.google.firebase.database.FirebaseDatabase
  * - NetworkMonitor (connectivity)
  * - FavoritesRepository (single source of truth)
  * - FavoritesSyncManager (online-trigger sync)
+ * - MovieLogRepository (single source of truth for Movie Log)
+ * - MovieLogSyncManager (online-trigger sync for Movie Log)
  *
  * Use [MovieMagicApp.from] from any Context to access these.
  */
@@ -27,6 +31,12 @@ class MovieMagicApp : Application() {
         private set
 
     lateinit var favoritesSyncManager: FavoritesSyncManager
+        private set
+
+    lateinit var movieLogRepository: MovieLogRepository
+        private set
+
+    lateinit var movieLogSyncManager: MovieLogSyncManager
         private set
 
     override fun onCreate() {
@@ -45,6 +55,7 @@ class MovieMagicApp : Application() {
 
         val db = AppDatabase.getDatabase(this)
         networkMonitor = NetworkMonitor(this)
+        
         favoritesRepository = FavoritesRepository(
             favoriteDao = db.favoriteDao(),
             networkMonitor = networkMonitor
@@ -54,9 +65,19 @@ class MovieMagicApp : Application() {
             networkMonitor = networkMonitor
         )
 
+        movieLogRepository = MovieLogRepository(
+            movieLogDao = db.movieLogDao(),
+            networkMonitor = networkMonitor
+        )
+        movieLogSyncManager = MovieLogSyncManager(
+            repository = movieLogRepository,
+            networkMonitor = networkMonitor
+        )
+
         // Begin observing connectivity and trigger sync on reconnect
         networkMonitor.startMonitoring()
         favoritesSyncManager.start()
+        movieLogSyncManager.start()
     }
 
     companion object {

--- a/app/src/main/java/com/example/movie_project/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [MovieLogEntry::class, FavoriteEntry::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -31,7 +31,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "movie_log_database" // keep same DB name to preserve existing data
                 )
-                    .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/example/movie_project/data/local/FavoriteDao.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/FavoriteDao.kt
@@ -64,28 +64,50 @@ interface FavoriteDao {
     suspend fun clearForUser(userId: String)
 
     /**
+     * Returns snapshot of all favorites for a user (used in conflict resolution).
+     */
+    @Query("SELECT * FROM favorites WHERE userId = :userId AND pendingDeletion = 0")
+    suspend fun getFavoritesSnapshot(userId: String): List<FavoriteEntry>
+
+    /**
      * Replaces the entire local cache for a user with a fresh set from Firebase.
-     * Preserves any pending operations by merging them back in after the replace.
+     * Preserves any pending operations by merging them back with timestamp-based conflict resolution.
      */
     @Transaction
     suspend fun replaceAllForUser(userId: String, entries: List<FavoriteEntry>) {
         // Save pending operations before clearing
         val pendingOps = getPendingSyncForUser(userId)
         clearForUser(userId)
+
         // Insert fresh data from Firebase
         entries.forEach { upsert(it) }
-        // Re-apply any pending operations that weren't in the Firebase data
+
+        // Re-apply pending operations with timestamp-based conflict resolution
         pendingOps.forEach { pending ->
-            val existsInFresh = entries.any { it.movieId == pending.movieId }
+            val firebaseEntry = entries.find { it.movieId == pending.movieId }
+
             if (pending.pendingDeletion) {
-                // If it was pending deletion and Firebase still has it, re-mark for deletion
-                if (existsInFresh) {
-                    markPendingDeletion(userId, pending.movieId)
+                // If marked for deletion locally, check timestamp
+                if (firebaseEntry != null) {
+                    if (pending.updatedAt > firebaseEntry.updatedAt) {
+                        // Local deletion is newer - keep the deletion
+                        markPendingDeletion(userId, pending.movieId)
+                    }
+                    // else: Firebase version is newer, deletion is obsolete
                 }
-                // If Firebase doesn't have it, the deletion already happened — skip
-            } else if (pending.pendingSync && !existsInFresh) {
-                // Offline add that Firebase doesn't know about yet — re-insert
-                upsert(pending)
+            } else if (pending.pendingSync) {
+                // Local edit/add pending
+                if (firebaseEntry != null) {
+                    // Conflict: compare timestamps
+                    if (pending.updatedAt > firebaseEntry.updatedAt) {
+                        // Local version is newer - keep it
+                        upsert(pending)
+                    }
+                    // else: Firebase version is newer, already inserted above
+                } else {
+                    // New local favorite not in Firebase yet
+                    upsert(pending)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/movie_project/data/local/Migrations.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/Migrations.kt
@@ -32,3 +32,86 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
         )
     }
 }
+
+/**
+ * MIGRATION_2_3: Updates movie_log table for multi-user support and Firebase sync.
+ * Changes:
+ * - Replaces auto-generated id with composite key (userId + entryId)
+ * - Adds sync metadata (pendingSync, pendingDeletion, updatedAt)
+ * - Migrates existing entries to current user
+ */
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // Get current user ID from Firebase Auth
+        // Note: During migration, if no user is logged in, entries will be assigned to "unknown"
+        // and can be reassigned later when user logs in
+        val currentUserId = try {
+            com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid ?: "unknown"
+        } catch (e: Exception) {
+            "unknown"
+        }
+        
+        // Create new table with updated schema
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `movie_log_new` (
+                `userId` TEXT NOT NULL,
+                `entryId` TEXT NOT NULL,
+                `movieTitle` TEXT NOT NULL DEFAULT '',
+                `year` TEXT NOT NULL DEFAULT '',
+                `dateWatched` TEXT NOT NULL DEFAULT '',
+                `directedBy` TEXT NOT NULL DEFAULT '',
+                `starring` TEXT NOT NULL DEFAULT '',
+                `rating` INTEGER NOT NULL DEFAULT 0,
+                `inTheater` INTEGER NOT NULL DEFAULT 0,
+                `atHome` INTEGER NOT NULL DEFAULT 0,
+                `firstWatch` INTEGER NOT NULL DEFAULT 0,
+                `rewatch` INTEGER NOT NULL DEFAULT 0,
+                `alone` INTEGER NOT NULL DEFAULT 0,
+                `withSomeone` INTEGER NOT NULL DEFAULT 0,
+                `notes` TEXT NOT NULL DEFAULT '',
+                `dateAdded` INTEGER NOT NULL,
+                `pendingSync` INTEGER NOT NULL DEFAULT 1,
+                `pendingDeletion` INTEGER NOT NULL DEFAULT 0,
+                `updatedAt` INTEGER NOT NULL,
+                PRIMARY KEY(`userId`, `entryId`)
+            )
+            """.trimIndent()
+        )
+        
+        // Create index on userId
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_movie_log_userId` ON `movie_log_new` (`userId`)"
+        )
+        
+        // Migrate existing data to current user with UUID entryIds
+        // Note: We use a SQL-based UUID generation for SQLite compatibility
+        db.execSQL(
+            """
+            INSERT INTO `movie_log_new` (
+                `userId`, `entryId`, `movieTitle`, `year`, `dateWatched`, `directedBy`,
+                `starring`, `rating`, `inTheater`, `atHome`, `firstWatch`, `rewatch`,
+                `alone`, `withSomeone`, `notes`, `dateAdded`, `pendingSync`,
+                `pendingDeletion`, `updatedAt`
+            )
+            SELECT 
+                '$currentUserId',
+                lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-' || 
+                     '4' || substr(hex(randomblob(2)), 2) || '-' || 
+                     substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || 
+                     hex(randomblob(6))),
+                `movieTitle`, `year`, `dateWatched`, `directedBy`, `starring`, `rating`,
+                `inTheater`, `atHome`, `firstWatch`, `rewatch`, `alone`, `withSomeone`,
+                `notes`, `dateAdded`,
+                1,
+                0,
+                `dateAdded`
+            FROM `movie_log`
+            """.trimIndent()
+        )
+        
+        // Drop old table and rename new table
+        db.execSQL("DROP TABLE `movie_log`")
+        db.execSQL("ALTER TABLE `movie_log_new` RENAME TO `movie_log`")
+    }
+}

--- a/app/src/main/java/com/example/movie_project/data/local/MovieLogDao.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/MovieLogDao.kt
@@ -2,31 +2,114 @@ package com.example.movie_project.data.local
 
 import androidx.lifecycle.LiveData
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Update
+import androidx.room.Transaction
 
 /**
  * Data Access Object for the movie_log table.
- * Provides CRUD operations for MovieLogEntry.
+ * Supports offline-first reads, writes, and sync queue operations.
+ * All operations are user-scoped for multi-user support.
  */
 @Dao
 interface MovieLogDao {
 
-    @Query("SELECT * FROM movie_log ORDER BY dateAdded DESC")
-    fun getAllEntries(): LiveData<List<MovieLogEntry>>
+    /**
+     * Returns all non-deleted entries for a given user, ordered by most recently added.
+     */
+    @Query("SELECT * FROM movie_log WHERE userId = :userId AND pendingDeletion = 0 ORDER BY dateAdded DESC")
+    fun getEntriesForUser(userId: String): LiveData<List<MovieLogEntry>>
 
-    @Query("SELECT * FROM movie_log WHERE id = :id")
-    fun getEntryById(id: Long): LiveData<MovieLogEntry>
+    /**
+     * Returns a single entry by userId and entryId (not pending deletion).
+     */
+    @Query("SELECT * FROM movie_log WHERE userId = :userId AND entryId = :entryId AND pendingDeletion = 0")
+    fun getEntryById(userId: String, entryId: String): LiveData<MovieLogEntry?>
 
+    /**
+     * Returns all entries that need to be synced to Firebase (added/updated or deleted offline).
+     */
+    @Query("SELECT * FROM movie_log WHERE userId = :userId AND (pendingSync = 1 OR pendingDeletion = 1)")
+    suspend fun getPendingSyncForUser(userId: String): List<MovieLogEntry>
+
+    /**
+     * Insert or replace an entry.
+     */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertEntry(entry: MovieLogEntry): Long
+    suspend fun upsert(entry: MovieLogEntry)
 
-    @Update
-    suspend fun updateEntry(entry: MovieLogEntry)
+    /**
+     * Soft-delete: marks an entry as pending deletion so it's hidden from the UI
+     * but retained until synced to Firebase.
+     */
+    @Query("UPDATE movie_log SET pendingDeletion = 1, pendingSync = 0, updatedAt = :now WHERE userId = :userId AND entryId = :entryId")
+    suspend fun markPendingDeletion(userId: String, entryId: String, now: Long = System.currentTimeMillis())
 
-    @Delete
-    suspend fun deleteEntry(entry: MovieLogEntry)
+    /**
+     * Hard-delete: permanently removes an entry after it has been synced.
+     */
+    @Query("DELETE FROM movie_log WHERE userId = :userId AND entryId = :entryId")
+    suspend fun hardDelete(userId: String, entryId: String)
+
+    /**
+     * Clears the pendingSync flag after a successful push to Firebase.
+     */
+    @Query("UPDATE movie_log SET pendingSync = 0 WHERE userId = :userId AND entryId = :entryId")
+    suspend fun clearPendingSync(userId: String, entryId: String)
+
+    /**
+     * Removes all entries for a user (used during full refresh from Firebase).
+     */
+    @Query("DELETE FROM movie_log WHERE userId = :userId")
+    suspend fun clearForUser(userId: String)
+
+    /**
+     * Returns snapshot of all entries for a user (used in conflict resolution).
+     */
+    @Query("SELECT * FROM movie_log WHERE userId = :userId AND pendingDeletion = 0")
+    suspend fun getEntriesSnapshot(userId: String): List<MovieLogEntry>
+
+    /**
+     * Replaces the entire local cache for a user with a fresh set from Firebase.
+     * Preserves any pending operations by merging them back with timestamp-based conflict resolution.
+     */
+    @Transaction
+    suspend fun replaceAllForUser(userId: String, entries: List<MovieLogEntry>) {
+        // Save pending operations before clearing
+        val pendingOps = getPendingSyncForUser(userId)
+        clearForUser(userId)
+
+        // Insert fresh data from Firebase
+        entries.forEach { upsert(it) }
+
+        // Re-apply pending operations with timestamp-based conflict resolution
+        pendingOps.forEach { pending ->
+            val firebaseEntry = entries.find { it.entryId == pending.entryId }
+
+            if (pending.pendingDeletion) {
+                // If marked for deletion locally, check timestamp
+                if (firebaseEntry != null) {
+                    if (pending.updatedAt > firebaseEntry.updatedAt) {
+                        // Local deletion is newer - keep the deletion
+                        markPendingDeletion(userId, pending.entryId)
+                    }
+                    // else: Firebase version is newer, deletion is obsolete
+                }
+            } else if (pending.pendingSync) {
+                // Local edit/add pending
+                if (firebaseEntry != null) {
+                    // Conflict: compare timestamps
+                    if (pending.updatedAt > firebaseEntry.updatedAt) {
+                        // Local version is newer - keep it
+                        upsert(pending)
+                    }
+                    // else: Firebase version is newer, already inserted above
+                } else {
+                    // New local entry not in Firebase yet
+                    upsert(pending)
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/movie_project/data/local/MovieLogEntry.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/MovieLogEntry.kt
@@ -1,16 +1,24 @@
 package com.example.movie_project.data.local
 
 import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room.Index
+import java.util.UUID
 
 /**
  * Room Entity representing a movie log entry.
  * Stores all details about a movie the user has watched or wants to watch.
+ * 
+ * Multi-user support with composite primary key (userId + entryId).
+ * Sync metadata supports offline-first writes and Firebase synchronization.
  */
-@Entity(tableName = "movie_log")
+@Entity(
+    tableName = "movie_log",
+    primaryKeys = ["userId", "entryId"],
+    indices = [Index("userId")]
+)
 data class MovieLogEntry(
-    @PrimaryKey(autoGenerate = true)
-    val id: Long = 0,
+    val userId: String = "",
+    val entryId: String = UUID.randomUUID().toString(),
     val movieTitle: String = "",
     val year: String = "",
     val dateWatched: String = "",
@@ -24,5 +32,9 @@ data class MovieLogEntry(
     val alone: Boolean = false,
     val withSomeone: Boolean = false,
     val notes: String = "",
-    val dateAdded: Long = System.currentTimeMillis()
+    val dateAdded: Long = System.currentTimeMillis(),
+    // Sync metadata
+    val pendingSync: Boolean = false,
+    val pendingDeletion: Boolean = false,
+    val updatedAt: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/com/example/movie_project/data/repository/MovieLogRepository.kt
+++ b/app/src/main/java/com/example/movie_project/data/repository/MovieLogRepository.kt
@@ -1,46 +1,280 @@
 package com.example.movie_project.data.repository
 
+import android.util.Log
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.example.movie_project.data.local.MovieLogDao
 import com.example.movie_project.data.local.MovieLogEntry
+import com.example.movie_project.util.NetworkMonitor
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
- * Repository for Movie Log feature.
- * Acts as a single source of truth, abstracting the data layer from ViewModels.
+ * Repository acting as the single source of truth for Movie Log.
+ *
+ * Strategy:
+ * - Reads always come from Room (offline-safe).
+ * - Writes go to Room first, then attempt Firebase if online; otherwise queued via pendingSync.
+ * - A real-time Firebase listener mirrors remote changes into Room when online.
+ *
+ * Firebase = source of truth on conflict (timestamp-based).
+ * Room    = local cache + offline write queue.
  */
-class MovieLogRepository(private val movieLogDao: MovieLogDao) {
+class MovieLogRepository(
+    private val movieLogDao: MovieLogDao,
+    private val networkMonitor: NetworkMonitor,
+    private val database: FirebaseDatabase = FirebaseDatabase.getInstance()
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> = _errorMessage
+
+    private var firebaseRef: DatabaseReference? = null
+    private var firebaseListener: ValueEventListener? = null
+    private var listeningForUserId: String? = null
+
+    // ----- Reads -----
 
     /**
-     * Returns all movie log entries ordered by date added (newest first).
+     * Observe movie log entries for a user from Room (offline-safe).
      */
-    val allEntries: LiveData<List<MovieLogEntry>> = movieLogDao.getAllEntries()
-
-    /**
-     * Returns a single movie log entry by its ID.
-     */
-    fun getEntryById(id: Long): LiveData<MovieLogEntry> {
-        return movieLogDao.getEntryById(id)
+    fun observeEntries(userId: String): LiveData<List<MovieLogEntry>> {
+        return movieLogDao.getEntriesForUser(userId)
     }
 
     /**
-     * Inserts a new movie log entry.
-     * @return the row ID of the newly inserted entry.
+     * Observe a single movie log entry by ID.
      */
-    suspend fun insertEntry(entry: MovieLogEntry): Long {
-        return movieLogDao.insertEntry(entry)
+    fun getEntryById(userId: String, entryId: String): LiveData<MovieLogEntry?> {
+        return movieLogDao.getEntryById(userId, entryId)
+    }
+
+    // ----- Writes -----
+
+    /**
+     * Add a movie log entry. Writes to Room immediately. If online, pushes to Firebase
+     * and clears the pendingSync flag. If offline, leaves it in the queue.
+     */
+    suspend fun addEntry(userId: String, entry: MovieLogEntry) {
+        val online = networkMonitor.isCurrentlyOnline()
+        val finalEntry = entry.copy(
+            userId = userId,
+            pendingSync = !online,
+            pendingDeletion = false,
+            updatedAt = System.currentTimeMillis()
+        )
+        movieLogDao.upsert(finalEntry)
+
+        if (online) {
+            try {
+                pushSingleToFirebase(userId, finalEntry)
+                movieLogDao.clearPendingSync(userId, finalEntry.entryId)
+            } catch (e: Exception) {
+                Log.w(TAG, "addEntry: Firebase push failed, queued for sync", e)
+                movieLogDao.upsert(finalEntry.copy(pendingSync = true))
+            }
+        }
     }
 
     /**
-     * Updates an existing movie log entry.
+     * Update a movie log entry. Writes to Room immediately. If online, pushes to Firebase
+     * and clears the pendingSync flag. If offline, leaves it in the queue.
      */
-    suspend fun updateEntry(entry: MovieLogEntry) {
-        movieLogDao.updateEntry(entry)
+    suspend fun updateEntry(userId: String, entry: MovieLogEntry) {
+        val online = networkMonitor.isCurrentlyOnline()
+        val finalEntry = entry.copy(
+            userId = userId,
+            pendingSync = !online,
+            updatedAt = System.currentTimeMillis()
+        )
+        movieLogDao.upsert(finalEntry)
+
+        if (online) {
+            try {
+                pushSingleToFirebase(userId, finalEntry)
+                movieLogDao.clearPendingSync(userId, finalEntry.entryId)
+            } catch (e: Exception) {
+                Log.w(TAG, "updateEntry: Firebase push failed, queued for sync", e)
+                movieLogDao.upsert(finalEntry.copy(pendingSync = true))
+            }
+        }
     }
 
     /**
-     * Deletes a movie log entry.
+     * Delete a movie log entry. Soft-deletes in Room (UI hides it instantly). If online,
+     * deletes from Firebase and hard-deletes locally. If offline, leaves it queued.
      */
-    suspend fun deleteEntry(entry: MovieLogEntry) {
-        movieLogDao.deleteEntry(entry)
+    suspend fun deleteEntry(userId: String, entryId: String) {
+        movieLogDao.markPendingDeletion(userId, entryId)
+
+        if (networkMonitor.isCurrentlyOnline()) {
+            try {
+                deleteSingleFromFirebase(userId, entryId)
+                movieLogDao.hardDelete(userId, entryId)
+            } catch (e: Exception) {
+                Log.w(TAG, "deleteEntry: Firebase delete failed, queued for sync", e)
+                // Leave it in pendingDeletion state for the SyncManager
+            }
+        }
+    }
+
+    // ----- Sync operations -----
+
+    /**
+     * Push all locally-queued operations (adds/updates + deletes) to Firebase.
+     * Called by SyncManager when connectivity is restored.
+     */
+    suspend fun pushPendingToFirebase(userId: String) {
+        if (!networkMonitor.isCurrentlyOnline()) return
+
+        val pending = movieLogDao.getPendingSyncForUser(userId)
+        for (entry in pending) {
+            try {
+                if (entry.pendingDeletion) {
+                    deleteSingleFromFirebase(userId, entry.entryId)
+                    movieLogDao.hardDelete(userId, entry.entryId)
+                } else if (entry.pendingSync) {
+                    pushSingleToFirebase(userId, entry)
+                    movieLogDao.clearPendingSync(userId, entry.entryId)
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "pushPendingToFirebase: failed for ${entry.entryId}", e)
+                // Leave in queue; will retry on next sync trigger
+            }
+        }
+    }
+
+    /**
+     * Pull the full movie log snapshot from Firebase and replace the local cache.
+     * Pending local operations are preserved by [MovieLogDao.replaceAllForUser]
+     * with timestamp-based conflict resolution.
+     */
+    suspend fun pullFromFirebase(userId: String) {
+        if (!networkMonitor.isCurrentlyOnline()) return
+
+        try {
+            val snapshot = readFirebaseSnapshot(userId)
+            val entries = snapshotToEntries(userId, snapshot)
+            movieLogDao.replaceAllForUser(userId, entries)
+        } catch (e: Exception) {
+            Log.e(TAG, "pullFromFirebase failed", e)
+            _errorMessage.postValue(e.localizedMessage)
+        }
+    }
+
+    /**
+     * Start real-time Firebase listener for a user.
+     * Mirrors remote changes into Room while online.
+     */
+    fun startFirebaseListener(userId: String) {
+        // Already listening for this user — skip
+        if (listeningForUserId == userId && firebaseListener != null) return
+
+        stopFirebaseListener()
+        listeningForUserId = userId
+        firebaseRef = database.reference.child("movieLog").child(userId)
+
+        firebaseListener = object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                scope.launch {
+                    try {
+                        val entries = snapshotToEntries(userId, snapshot)
+                        movieLogDao.replaceAllForUser(userId, entries)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Firebase listener: replaceAll failed", e)
+                    }
+                }
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                Log.e(TAG, "Firebase listener cancelled: ${error.message}")
+                _errorMessage.postValue(error.message)
+            }
+        }
+
+        firebaseRef?.addValueEventListener(firebaseListener!!)
+    }
+
+    /**
+     * Stop the real-time Firebase listener (call on sign-out or VM cleared).
+     */
+    fun stopFirebaseListener() {
+        firebaseListener?.let { listener ->
+            firebaseRef?.removeEventListener(listener)
+        }
+        firebaseListener = null
+        firebaseRef = null
+        listeningForUserId = null
+    }
+
+    /**
+     * Clear all locally-cached entries for a user (used on sign-out).
+     */
+    suspend fun clearLocalForUser(userId: String) {
+        movieLogDao.clearForUser(userId)
+    }
+
+    // ----- Firebase helpers -----
+
+    private suspend fun pushSingleToFirebase(userId: String, entry: MovieLogEntry) =
+        suspendCancellableCoroutine { cont ->
+            database.reference
+                .child("movieLog")
+                .child(userId)
+                .child(entry.entryId)
+                .setValue(entry)
+                .addOnSuccessListener { cont.resume(Unit) }
+                .addOnFailureListener { cont.resumeWithException(it) }
+        }
+
+    private suspend fun deleteSingleFromFirebase(userId: String, entryId: String) =
+        suspendCancellableCoroutine { cont ->
+            database.reference
+                .child("movieLog")
+                .child(userId)
+                .child(entryId)
+                .removeValue()
+                .addOnSuccessListener { cont.resume(Unit) }
+                .addOnFailureListener { cont.resumeWithException(it) }
+        }
+
+    private suspend fun readFirebaseSnapshot(userId: String): DataSnapshot =
+        suspendCancellableCoroutine { cont ->
+            database.reference
+                .child("movieLog")
+                .child(userId)
+                .get()
+                .addOnSuccessListener { cont.resume(it) }
+                .addOnFailureListener { cont.resumeWithException(it) }
+        }
+
+    private fun snapshotToEntries(userId: String, snapshot: DataSnapshot): List<MovieLogEntry> {
+        val list = mutableListOf<MovieLogEntry>()
+        if (!snapshot.exists()) return list
+        for (child in snapshot.children) {
+            val entry = child.getValue(MovieLogEntry::class.java) ?: continue
+            list.add(entry.copy(
+                userId = userId,
+                pendingSync = false,
+                pendingDeletion = false
+            ))
+        }
+        return list
+    }
+
+    companion object {
+        private const val TAG = "MovieLogRepository"
     }
 }

--- a/app/src/main/java/com/example/movie_project/data/sync/MovieLogSyncManager.kt
+++ b/app/src/main/java/com/example/movie_project/data/sync/MovieLogSyncManager.kt
@@ -1,0 +1,69 @@
+package com.example.movie_project.data.sync
+
+import android.util.Log
+import androidx.lifecycle.Observer
+import com.example.movie_project.data.repository.MovieLogRepository
+import com.example.movie_project.util.NetworkMonitor
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Coordinates connectivity-driven sync between Room and Firebase for Movie Log.
+ *
+ * When connectivity returns:
+ *   1) push all queued local operations to Firebase
+ *   2) pull the latest Firebase snapshot into Room
+ *
+ * Lives at application scope.
+ */
+class MovieLogSyncManager(
+    private val repository: MovieLogRepository,
+    private val networkMonitor: NetworkMonitor,
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val onlineObserver = Observer<Boolean> { isOnline ->
+        if (isOnline == true) {
+            triggerSync()
+        }
+    }
+
+    /**
+     * Begin observing connectivity and reacting to online transitions.
+     * Call once from Application.onCreate.
+     */
+    fun start() {
+        networkMonitor.isOnline.observeForever(onlineObserver)
+    }
+
+    /**
+     * Stop observing connectivity. Call on app teardown if necessary.
+     */
+    fun stop() {
+        networkMonitor.isOnline.removeObserver(onlineObserver)
+    }
+
+    /**
+     * Manually trigger a full sync (push pending → pull from Firebase).
+     */
+    fun triggerSync() {
+        val userId = auth.currentUser?.uid ?: return
+        scope.launch {
+            try {
+                repository.pushPendingToFirebase(userId)
+                repository.pullFromFirebase(userId)
+            } catch (e: Exception) {
+                Log.e(TAG, "Sync failed", e)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "MovieLogSyncManager"
+    }
+}

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailActivity.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailActivity.kt
@@ -9,6 +9,7 @@ import com.example.movie_project.R
 import com.example.movie_project.data.local.MovieLogEntry
 import com.example.movie_project.databinding.ActivityMovieLogDetailBinding
 import com.example.movie_project.util.HapticUtil
+import java.util.UUID
 
 /**
  * Activity for creating or editing a movie log entry.
@@ -24,7 +25,7 @@ class MovieLogDetailActivity : AppCompatActivity() {
     private val viewModel: MovieLogDetailViewModel by viewModels()
 
     private var currentRating = 0
-    private var editEntryId: Long = -1L
+    private var editEntryId: String? = null
     private var editEntryDateAdded: Long = System.currentTimeMillis()
     private lateinit var starViews: List<ImageView>
 
@@ -43,11 +44,9 @@ class MovieLogDetailActivity : AppCompatActivity() {
             }
         }
 
-        // Check if editing an existing entry
-        editEntryId = intent.getLongExtra(EXTRA_ENTRY_ID, -1L)
-        if (editEntryId != -1L) {
-            loadExistingEntry(editEntryId)
-        }
+        // Check if editing an existing entry (entryId is now a String UUID)
+        editEntryId = intent.getStringExtra(EXTRA_ENTRY_ID)
+        editEntryId?.let { loadExistingEntry(it) }
     }
 
     /**
@@ -109,8 +108,10 @@ class MovieLogDetailActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
+            // Build entry with userId placeholder (repository will set the real userId)
             val entry = MovieLogEntry(
-                id = if (editEntryId != -1L) editEntryId else 0,
+                userId = "",  // Will be set by repository
+                entryId = editEntryId ?: UUID.randomUUID().toString(),
                 movieTitle = movieTitle,
                 year = binding.etYear.text.toString().trim(),
                 dateWatched = binding.etDateWatched.text.toString().trim(),
@@ -124,10 +125,10 @@ class MovieLogDetailActivity : AppCompatActivity() {
                 alone = binding.cbAlone.isChecked,
                 withSomeone = binding.cbWithSomeone.isChecked,
                 notes = binding.etNotes.text.toString().trim(),
-                dateAdded = if (editEntryId != -1L) editEntryDateAdded else System.currentTimeMillis()
+                dateAdded = if (editEntryId != null) editEntryDateAdded else System.currentTimeMillis()
             )
 
-            if (editEntryId != -1L) {
+            if (editEntryId != null) {
                 viewModel.updateEntry(entry) {
                     runOnUiThread {
                         Toast.makeText(this, "Movie updated!", Toast.LENGTH_SHORT).show()
@@ -148,8 +149,8 @@ class MovieLogDetailActivity : AppCompatActivity() {
     /**
      * Loads an existing entry for editing and populates the form fields.
      */
-    private fun loadExistingEntry(id: Long) {
-        viewModel.getEntryById(id).observe(this) { entry ->
+    private fun loadExistingEntry(entryId: String) {
+        viewModel.getEntryById(entryId).observe(this) { entry ->
             entry?.let {
                 editEntryDateAdded = it.dateAdded
                 binding.etMovieTitle.setText(it.movieTitle)

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailViewModel.kt
@@ -6,43 +6,52 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.example.movie_project.data.local.AppDatabase
+import com.example.movie_project.MovieMagicApp
 import com.example.movie_project.data.local.MovieLogEntry
 import com.example.movie_project.data.repository.MovieLogRepository
+import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.launch
 
 /**
  * ViewModel for MovieLogDetailActivity.
- * Handles loading, saving, and updating movie log entries via the repository.
+ * Handles loading, saving, updating, and deleting movie log entries via the repository.
+ * Uses Firebase Auth userId for all operations.
  */
 class MovieLogDetailViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val repository: MovieLogRepository
+    private val repository: MovieLogRepository =
+        MovieMagicApp.from(application).movieLogRepository
 
     private val _errorMessage = MutableLiveData<String?>()
     val errorMessage: LiveData<String?> = _errorMessage
 
-    init {
-        val dao = AppDatabase.getDatabase(application).movieLogDao()
-        repository = MovieLogRepository(dao)
-    }
+    private val userId: String?
+        get() = FirebaseAuth.getInstance().currentUser?.uid
 
     /**
-     * Loads a single movie log entry by ID for editing.
+     * Loads a single movie log entry by entryId for editing.
      */
-    fun getEntryById(id: Long): LiveData<MovieLogEntry> {
-        return repository.getEntryById(id)
+    fun getEntryById(entryId: String): LiveData<MovieLogEntry?> {
+        val uid = userId ?: run {
+            _errorMessage.postValue("Please sign in to view entries")
+            return MutableLiveData(null)
+        }
+        return repository.getEntryById(uid, entryId)
     }
 
     /**
      * Inserts a new movie log entry.
-     * @param entry the entry to insert
+     * @param entry the entry to insert (userId will be set automatically)
      * @param onComplete callback invoked after successful insertion
      */
     fun insertEntry(entry: MovieLogEntry, onComplete: () -> Unit) {
+        val uid = userId ?: run {
+            _errorMessage.postValue("Please sign in to save entries")
+            return
+        }
         viewModelScope.launch {
             try {
-                repository.insertEntry(entry)
+                repository.addEntry(uid, entry)
                 onComplete()
             } catch (e: Exception) {
                 Log.e("MovieLogDetailVM", "Insert failed: ${e.message}")
@@ -53,17 +62,42 @@ class MovieLogDetailViewModel(application: Application) : AndroidViewModel(appli
 
     /**
      * Updates an existing movie log entry.
-     * @param entry the entry to update
+     * @param entry the entry to update (userId will be set automatically)
      * @param onComplete callback invoked after successful update
      */
     fun updateEntry(entry: MovieLogEntry, onComplete: () -> Unit) {
+        val uid = userId ?: run {
+            _errorMessage.postValue("Please sign in to update entries")
+            return
+        }
         viewModelScope.launch {
             try {
-                repository.updateEntry(entry)
+                repository.updateEntry(uid, entry)
                 onComplete()
             } catch (e: Exception) {
                 Log.e("MovieLogDetailVM", "Update failed: ${e.message}")
                 _errorMessage.postValue(e.localizedMessage ?: "Failed to update movie log entry")
+            }
+        }
+    }
+
+    /**
+     * Deletes a movie log entry.
+     * @param entryId the ID of the entry to delete
+     * @param onComplete callback invoked after successful deletion
+     */
+    fun deleteEntry(entryId: String, onComplete: () -> Unit) {
+        val uid = userId ?: run {
+            _errorMessage.postValue("Please sign in to delete entries")
+            return
+        }
+        viewModelScope.launch {
+            try {
+                repository.deleteEntry(uid, entryId)
+                onComplete()
+            } catch (e: Exception) {
+                Log.e("MovieLogDetailVM", "Delete failed: ${e.message}")
+                _errorMessage.postValue(e.localizedMessage ?: "Failed to delete movie log entry")
             }
         }
     }

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogFragment.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogFragment.kt
@@ -64,11 +64,11 @@ class MovieLogFragment : Fragment(), MovieLogClickListener {
 
     /**
      * Called when a movie log item is clicked.
-     * Navigates to the detail screen for editing.
+     * Navigates to the detail screen for editing using the UUID-based entryId.
      */
     override fun onMovieLogClicked(entry: MovieLogEntry) {
         val intent = Intent(activity, MovieLogDetailActivity::class.java)
-        intent.putExtra(MovieLogDetailActivity.EXTRA_ENTRY_ID, entry.id)
+        intent.putExtra(MovieLogDetailActivity.EXTRA_ENTRY_ID, entry.entryId)
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogViewModel.kt
@@ -3,27 +3,69 @@ package com.example.movie_project.views.movielog
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import com.example.movie_project.data.local.AppDatabase
+import androidx.lifecycle.Observer
+import com.example.movie_project.MovieMagicApp
 import com.example.movie_project.data.local.MovieLogEntry
 import com.example.movie_project.data.repository.MovieLogRepository
+import com.google.firebase.auth.FirebaseAuth
 
 /**
  * ViewModel for MovieLogFragment.
- * Provides all movie log entries to the UI via LiveData.
+ *
+ * Reads come from the local Room cache (offline-safe). The repository's
+ * Firebase listener mirrors remote updates into Room when online.
  */
 class MovieLogViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val repository: MovieLogRepository
+    private val repository: MovieLogRepository =
+        MovieMagicApp.from(application).movieLogRepository
 
     private val _errorMessage = MutableLiveData<String?>()
     val errorMessage: LiveData<String?> = _errorMessage
 
-    val allEntries: LiveData<List<MovieLogEntry>>
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
+
+    /**
+     * Movie log entries driven by Room — always available, online or offline.
+     */
+    private val _allEntries = MediatorLiveData<List<MovieLogEntry>>()
+    val allEntries: LiveData<List<MovieLogEntry>> = _allEntries
+
+    private val repoErrorObserver = Observer<String?> { msg ->
+        if (!msg.isNullOrEmpty()) _errorMessage.postValue(msg)
+    }
 
     init {
-        val dao = AppDatabase.getDatabase(application).movieLogDao()
-        repository = MovieLogRepository(dao)
-        allEntries = repository.allEntries
+        val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
+
+        if (currentUserId != null) {
+            _isLoading.postValue(true)
+
+            // Mirror Room → allEntries LiveData
+            _allEntries.addSource(repository.observeEntries(currentUserId)) { list ->
+                _isLoading.postValue(false)
+                _allEntries.value = list
+            }
+
+            // Start real-time Firebase listener so Room stays fresh while online
+            repository.startFirebaseListener(currentUserId)
+        } else {
+            _allEntries.value = emptyList()
+            _errorMessage.postValue("Please sign in to view your movie log")
+            _isLoading.postValue(false)
+        }
+
+        // Forward repository errors to the UI
+        repository.errorMessage.observeForever(repoErrorObserver)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        repository.errorMessage.removeObserver(repoErrorObserver)
+        // Listener is app-scoped via the repository singleton — keep it running so
+        // Room stays fresh as the user navigates. It is stopped explicitly on sign-out.
     }
 }


### PR DESCRIPTION
## Firebase Integration for Movie Log — Complete ✅

1. **MovieLogEntry.kt** — Added `userId`, `entryId` (UUID), `pendingSync`, `pendingDeletion`, `updatedAt` fields with composite primary key
2. **MovieLogDao.kt** — Rewritten with user-scoped queries, sync operations, and timestamp-based conflict resolution in `replaceAllForUser`
3. **Migrations.kt** — Added `MIGRATION_2_3` to migrate existing data to current user with UUID entry IDs
4. **AppDatabase.kt** — Bumped to version 3, added `MIGRATION_2_3`
5. **MovieLogRepository.kt** — Fully rewritten with offline-first Firebase sync (push/pull/real-time listener), mirroring `FavoritesRepository`
6. **FavoriteDao.kt** — Updated `replaceAllForUser` with timestamp-based conflict resolution (as requested)
7. **MovieMagicApp.kt** — Wired up `MovieLogRepository` and `MovieLogSyncManager` as app-scoped singletons

### Files Modified (4 UI/ViewModel files):
8. **MovieLogViewModel.kt** — Now uses app-scoped repository, user-scoped queries, and starts Firebase listener (mirrors `FavoritesViewModel`)
9. **MovieLogDetailViewModel.kt** — Uses app-scoped repository with userId, new API (`addEntry`/`updateEntry`/`deleteEntry`)
10. **MovieLogFragment.kt** — Passes `entry.entryId` (String UUID) instead of old `entry.id` (Long)
11. **MovieLogDetailActivity.kt** — Uses String-based `entryId`, UUID generation for new entries, updated ViewModel API

### New File Created :
12. **MovieLogSyncManager.kt** — Connectivity-driven sync manager that pushes pending operations and pulls from Firebase when online

### Architecture: Room ↔ Firebase sync with offline-first design, timestamp-based conflict resolution, and real-time Firebase listener — identical pattern to Favorites.