### PR TITLE
Refactor Model package

### DIFF
--- a/app/src/main/java/com/example/movie_project/models/domain/MovieModel.kt
+++ b/app/src/main/java/com/example/movie_project/models/domain/MovieModel.kt
@@ -1,0 +1,21 @@
+package com.example.movie_project.models.domain
+
+import java.io.Serializable
+
+/**
+ * Domain/UI model for a movie.
+ *
+ * This is the type used across ViewModels, repositories, adapters, Compose UI,
+ * and is passed between screens as a [Serializable] intent extra. It is
+ * deliberately free of any network (Gson) annotations — mapping from the
+ * network layer happens via [com.example.movie_project.models.dto.MovieDto.toMovieModel].
+ */
+data class MovieModel(
+    val id: Int = 0,
+    val title: String? = "",
+    val overview: String? = "",
+    val poster_path: String? = "",
+    val voteAverage: Float? = 0.0f,
+    val release_date: String? = "",
+    var poster: String = "https://image.tmdb.org/t/p/w500$poster_path"
+) : Serializable

--- a/app/src/main/java/com/example/movie_project/models/domain/UsersModel.kt
+++ b/app/src/main/java/com/example/movie_project/models/domain/UsersModel.kt
@@ -1,0 +1,12 @@
+package com.example.movie_project.models.domain
+
+/**
+ * Domain model representing an application user.
+ *
+ * Stored to / read from Firebase Realtime Database (hence the nullable,
+ * default-valued fields required for Firebase's no-arg deserialization).
+ */
+data class UsersModel(
+    var email: String? = null,
+    var uid: String? = null,
+)

--- a/app/src/main/java/com/example/movie_project/models/dto/MovieDto.kt
+++ b/app/src/main/java/com/example/movie_project/models/dto/MovieDto.kt
@@ -1,0 +1,37 @@
+package com.example.movie_project.models.dto
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Network DTO representing a single movie as returned by the TMDB API.
+ *
+ * This type is confined to the network boundary (Retrofit + Gson). It is
+ * mapped to the domain [com.example.movie_project.models.domain.MovieModel]
+ * via [toMovieModel] before being exposed to repositories / ViewModels / UI.
+ *
+ * NOTE: [voteAverage] intentionally maps to the JSON key "voteAverage" to
+ * preserve the original (pre-refactor) behavior. The actual TMDB key is
+ * "vote_average"; correcting this is tracked as a follow-up so this refactor
+ * stays behavior-preserving.
+ */
+data class MovieDto(
+    @SerializedName("id")
+    @Expose
+    val id: Int = 0,
+    @SerializedName("title")
+    @Expose
+    val title: String? = "",
+    @SerializedName("overview")
+    @Expose
+    val overview: String? = "",
+    @SerializedName("poster_path")
+    @Expose
+    val posterPath: String? = "",
+    @SerializedName("voteAverage")
+    @Expose
+    val voteAverage: Float? = 0.0f,
+    @SerializedName("release_date")
+    @Expose
+    val releaseDate: String? = "",
+)

--- a/app/src/main/java/com/example/movie_project/models/dto/MovieDtoMappers.kt
+++ b/app/src/main/java/com/example/movie_project/models/dto/MovieDtoMappers.kt
@@ -1,0 +1,23 @@
+package com.example.movie_project.models.dto
+
+import com.example.movie_project.models.domain.MovieModel
+
+/**
+ * Maps a network [MovieDto] to the domain [MovieModel] used by the rest of the app.
+ *
+ * The domain model's `poster` URL is derived from `poster_path` via its
+ * constructor default, matching the existing image-loading convention.
+ */
+fun MovieDto.toMovieModel(): MovieModel = MovieModel(
+    id = id,
+    title = title,
+    overview = overview,
+    poster_path = posterPath,
+    voteAverage = voteAverage,
+    release_date = releaseDate,
+)
+
+/**
+ * Maps a list of [MovieDto] to a list of domain [MovieModel].
+ */
+fun List<MovieDto>.toMovieModels(): List<MovieModel> = map { it.toMovieModel() }

--- a/app/src/main/java/com/example/movie_project/models/dto/MovieResponse.kt
+++ b/app/src/main/java/com/example/movie_project/models/dto/MovieResponse.kt
@@ -1,0 +1,22 @@
+package com.example.movie_project.models.dto
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Network DTO wrapping a paginated list of movies returned by the TMDB API.
+ */
+data class MovieResponse(
+    @SerializedName("page")
+    @Expose
+    val page: Int?,
+    @SerializedName("results")
+    @Expose
+    val results: List<MovieDto>,
+    @SerializedName("total_pages")
+    @Expose
+    val totalPages: Int?,
+    @SerializedName("total_results")
+    @Expose
+    val totalResults: Int?
+)

--- a/app/src/main/java/com/example/movie_project/views/search/SearchUiState.kt
+++ b/app/src/main/java/com/example/movie_project/views/search/SearchUiState.kt
@@ -1,6 +1,6 @@
 package com.example.movie_project.views.search
 
-import com.example.movie_project.models.MovieModel
+import com.example.movie_project.models.domain.MovieModel
 
 /**
  * Immutable UI state for the Search screen.


### PR DESCRIPTION
__Goal:__ Eliminate the flat `models/` package where one `MovieModel` served simultaneously as network DTO, domain model, and UI model — establishing a clean network/domain boundary.

__New structure created:__

- `models/dto/MovieDto.kt` — the Gson-annotated TMDB network shape (single movie).
- `models/dto/MovieResponse.kt` — network wrapper; its `results` is now `List<MovieDto>` (was `List<MovieModel>`).
- `models/dto/MovieDtoMappers.kt` — `MovieDto.toMovieModel()` and `List<MovieDto>.toMovieModels()`.
- `models/domain/MovieModel.kt` — the domain/UI model (moved, now free of any Gson coupling).
- `models/domain/UsersModel.kt` — domain model (moved).
