### PR TITLE
Update architecture

### DIFF
--- a/app/src/androidTest/java/com/example/movie_project/data/local/MovieLogDaoTest.kt
+++ b/app/src/androidTest/java/com/example/movie_project/data/local/MovieLogDaoTest.kt
@@ -7,7 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -17,8 +17,8 @@ import org.junit.runner.RunWith
 
 /**
  * Instrumented tests for [MovieLogDao].
- * Uses an in-memory Room database so tests run fast and don't affect real data.
- * Must run on a device or emulator (androidTest).
+ * Uses an in-memory Room database to verify CRUD, per-user isolation,
+ * sync queue queries, and the replaceAllForUser transaction.
  */
 @RunWith(AndroidJUnit4::class)
 class MovieLogDaoTest {
@@ -28,6 +28,32 @@ class MovieLogDaoTest {
 
     private lateinit var database: AppDatabase
     private lateinit var dao: MovieLogDao
+
+    private val userA = "userA"
+    private val userB = "userB"
+
+    private fun entry(
+        userId: String,
+        entryId: String,
+        movieTitle: String = "Movie $entryId",
+        dateAdded: Long = 1000L,
+        pendingSync: Boolean = false,
+        pendingDeletion: Boolean = false,
+        updatedAt: Long = dateAdded
+    ) = MovieLogEntry(
+        userId = userId,
+        entryId = entryId,
+        movieTitle = movieTitle,
+        year = "2010",
+        directedBy = "Director",
+        starring = "Star",
+        rating = 5,
+        inTheater = true,
+        dateAdded = dateAdded,
+        pendingSync = pendingSync,
+        pendingDeletion = pendingDeletion,
+        updatedAt = updatedAt
+    )
 
     @Before
     fun setup() {
@@ -45,41 +71,27 @@ class MovieLogDaoTest {
     }
 
     @Test
-    fun insertAndRetrieveEntry() = runTest {
-        val entry = MovieLogEntry(
-            movieTitle = "Inception",
-            year = "2010",
-            directedBy = "Christopher Nolan",
-            starring = "Leonardo DiCaprio",
-            rating = 5,
-            inTheater = true,
-            dateAdded = 1000L
-        )
+    fun upsertAndObserve_returnsOnlyForRequestedUser() = runTest {
+        dao.upsert(entry(userA, "a1", "A1"))
+        dao.upsert(entry(userA, "a2", "A2"))
+        dao.upsert(entry(userB, "b1", "B1"))
 
-        val insertedId = dao.insertEntry(entry)
-        assertTrue(insertedId > 0)
+        val aList = dao.getEntriesForUser(userA).getOrAwaitValue()
+        val bList = dao.getEntriesForUser(userB).getOrAwaitValue()
 
-        val retrieved = dao.getEntryById(insertedId).getOrAwaitValue()
-        assertNotNull(retrieved)
-        assertEquals("Inception", retrieved.movieTitle)
-        assertEquals("2010", retrieved.year)
-        assertEquals("Christopher Nolan", retrieved.directedBy)
-        assertEquals("Leonardo DiCaprio", retrieved.starring)
-        assertEquals(5, retrieved.rating)
-        assertTrue(retrieved.inTheater)
+        assertEquals(2, aList.size)
+        assertEquals(1, bList.size)
+        assertTrue(aList.all { it.userId == userA })
+        assertEquals("B1", bList[0].movieTitle)
     }
 
     @Test
-    fun getAllEntries_orderedByDateDesc() = runTest {
-        val oldest = MovieLogEntry(movieTitle = "Oldest", dateAdded = 1000L)
-        val middle = MovieLogEntry(movieTitle = "Middle", dateAdded = 2000L)
-        val newest = MovieLogEntry(movieTitle = "Newest", dateAdded = 3000L)
+    fun entriesOrderedByDateAddedDesc() = runTest {
+        dao.upsert(entry(userA, "old", "Oldest", dateAdded = 1000L))
+        dao.upsert(entry(userA, "mid", "Middle", dateAdded = 2000L))
+        dao.upsert(entry(userA, "new", "Newest", dateAdded = 3000L))
 
-        dao.insertEntry(oldest)
-        dao.insertEntry(middle)
-        dao.insertEntry(newest)
-
-        val entries = dao.getAllEntries().getOrAwaitValue()
+        val entries = dao.getEntriesForUser(userA).getOrAwaitValue()
 
         assertEquals(3, entries.size)
         assertEquals("Newest", entries[0].movieTitle)
@@ -88,43 +100,118 @@ class MovieLogDaoTest {
     }
 
     @Test
-    fun updateEntry_modifiesExistingRow() = runTest {
-        val entry = MovieLogEntry(movieTitle = "Original Title", dateAdded = 1000L)
-        val id = dao.insertEntry(entry)
+    fun getEntryById_returnsCorrectEntry() = runTest {
+        dao.upsert(entry(userA, "e1", "Movie A"))
+        dao.upsert(entry(userA, "e2", "Movie B"))
+        dao.upsert(entry(userA, "e3", "Movie C"))
 
-        val updated = entry.copy(id = id, movieTitle = "Updated Title")
-        dao.updateEntry(updated)
-
-        val retrieved = dao.getEntryById(id).getOrAwaitValue()
-        assertEquals("Updated Title", retrieved.movieTitle)
+        val retrieved = dao.getEntryById(userA, "e2").getOrAwaitValue()
+        assertTrue(retrieved != null)
+        assertEquals("Movie B", retrieved?.movieTitle)
     }
 
     @Test
-    fun deleteEntry_removesFromDatabase() = runTest {
-        val entry = MovieLogEntry(movieTitle = "To Delete", dateAdded = 1000L)
-        val id = dao.insertEntry(entry)
+    fun upsert_updatesExistingEntry() = runTest {
+        dao.upsert(entry(userA, "e1", "Original Title"))
+        dao.upsert(entry(userA, "e1", "Updated Title"))
 
-        val inserted = dao.getEntryById(id).getOrAwaitValue()
-        assertNotNull(inserted)
+        val retrieved = dao.getEntryById(userA, "e1").getOrAwaitValue()
+        assertEquals("Updated Title", retrieved?.movieTitle)
 
-        dao.deleteEntry(inserted)
+        // Still only one row for that user/entryId combo (REPLACE, not duplicate)
+        val all = dao.getEntriesForUser(userA).getOrAwaitValue()
+        assertEquals(1, all.size)
+    }
 
-        val allEntries = dao.getAllEntries().getOrAwaitValue()
+    @Test
+    fun markPendingDeletion_excludedFromObserveAndGetById() = runTest {
+        dao.upsert(entry(userA, "visible", "Visible"))
+        dao.upsert(entry(userA, "hidden", "Hidden"))
+        dao.markPendingDeletion(userA, "hidden")
+
+        val list = dao.getEntriesForUser(userA).getOrAwaitValue()
+        assertEquals(1, list.size)
+        assertEquals("Visible", list[0].movieTitle)
+
+        val hidden = dao.getEntryById(userA, "hidden").getOrAwaitValue()
+        assertNull(hidden)
+    }
+
+    @Test
+    fun hardDelete_removesFromDatabase() = runTest {
+        dao.upsert(entry(userA, "e1", "To Delete"))
+        dao.hardDelete(userA, "e1")
+
+        val allEntries = dao.getEntriesForUser(userA).getOrAwaitValue()
         assertTrue(allEntries.isEmpty())
     }
 
     @Test
-    fun getEntryById_returnsCorrectEntry() = runTest {
-        val entry1 = MovieLogEntry(movieTitle = "Movie A", dateAdded = 1000L)
-        val entry2 = MovieLogEntry(movieTitle = "Movie B", dateAdded = 2000L)
-        val entry3 = MovieLogEntry(movieTitle = "Movie C", dateAdded = 3000L)
+    fun clearForUser_onlyAffectsThatUser() = runTest {
+        dao.upsert(entry(userA, "a1"))
+        dao.upsert(entry(userB, "b1"))
+        dao.clearForUser(userA)
 
-        dao.insertEntry(entry1)
-        val id2 = dao.insertEntry(entry2)
-        dao.insertEntry(entry3)
+        assertTrue(dao.getEntriesForUser(userA).getOrAwaitValue().isEmpty())
+        assertEquals(1, dao.getEntriesForUser(userB).getOrAwaitValue().size)
+    }
 
-        val retrieved = dao.getEntryById(id2).getOrAwaitValue()
-        assertNotNull(retrieved)
-        assertEquals("Movie B", retrieved.movieTitle)
+    @Test
+    fun pendingSyncQueue_returnsBothAddsAndDeletes() = runTest {
+        dao.upsert(entry(userA, "e1", pendingSync = true)) // offline add
+        dao.upsert(entry(userA, "e2")) // already synced
+        dao.upsert(entry(userA, "e3"))
+        dao.markPendingDeletion(userA, "e3") // offline delete
+
+        val pending = dao.getPendingSyncForUser(userA)
+        assertEquals(2, pending.size)
+        val ids = pending.map { it.entryId }.toSet()
+        assertTrue(ids.contains("e1"))
+        assertTrue(ids.contains("e3"))
+    }
+
+    @Test
+    fun clearPendingSync_clearsFlagOnly() = runTest {
+        dao.upsert(entry(userA, "e1", pendingSync = true))
+        dao.clearPendingSync(userA, "e1")
+
+        val list = dao.getEntriesForUser(userA).getOrAwaitValue()
+        assertEquals(1, list.size)
+        assertFalse(list[0].pendingSync)
+    }
+
+    @Test
+    fun replaceAllForUser_preservesPendingOfflineAdd() = runTest {
+        // Existing synced entry from earlier
+        dao.upsert(entry(userA, "e1", "Old"))
+        // User added a new entry while offline (not yet on Firebase)
+        dao.upsert(entry(userA, "offline", "OfflineAdd", pendingSync = true))
+
+        // Firebase snapshot only contains the old one
+        val fresh = listOf(entry(userA, "e1", "Old (server)"))
+        dao.replaceAllForUser(userA, fresh)
+
+        val list = dao.getEntriesForUser(userA).getOrAwaitValue()
+        val ids = list.map { it.entryId }.toSet()
+        assertTrue("Offline add should be preserved", ids.contains("offline"))
+        assertTrue("Server data should be present", ids.contains("e1"))
+    }
+
+    @Test
+    fun replaceAllForUser_preservesPendingOfflineDelete() = runTest {
+        dao.upsert(entry(userA, "e1", "ToDelete"))
+        dao.markPendingDeletion(userA, "e1")
+
+        // Firebase still has it because the delete hasn't synced yet
+        val fresh = listOf(entry(userA, "e1", "ToDelete (server)"))
+        dao.replaceAllForUser(userA, fresh)
+
+        // Should be hidden (pendingDeletion still set)
+        val visible = dao.getEntriesForUser(userA).getOrAwaitValue()
+        assertTrue("Pending delete should remain hidden", visible.isEmpty())
+
+        val pending = dao.getPendingSyncForUser(userA)
+        assertEquals(1, pending.size)
+        assertTrue(pending[0].pendingDeletion)
     }
 }

--- a/app/src/test/java/com/example/movie_project/data/local/MovieLogEntryTest.kt
+++ b/app/src/test/java/com/example/movie_project/data/local/MovieLogEntryTest.kt
@@ -15,7 +15,9 @@ class MovieLogEntryTest {
     fun `default values are correct when no arguments provided`() {
         val entry = MovieLogEntry()
 
-        assertEquals(0L, entry.id)
+        assertEquals("", entry.userId)
+        // entryId defaults to a randomly generated UUID string
+        assertTrue(entry.entryId.isNotBlank())
         assertEquals("", entry.movieTitle)
         assertEquals("", entry.year)
         assertEquals("", entry.dateWatched)
@@ -31,12 +33,16 @@ class MovieLogEntryTest {
         assertEquals("", entry.notes)
         // dateAdded should be a positive timestamp (not 0)
         assertTrue(entry.dateAdded > 0)
+        assertFalse(entry.pendingSync)
+        assertFalse(entry.pendingDeletion)
+        assertTrue(entry.updatedAt > 0)
     }
 
     @Test
     fun `custom values are retained when provided`() {
         val entry = MovieLogEntry(
-            id = 42L,
+            userId = "user-1",
+            entryId = "entry-42",
             movieTitle = "Inception",
             year = "2010",
             dateWatched = "July 16, 2010",
@@ -50,10 +56,14 @@ class MovieLogEntryTest {
             alone = false,
             withSomeone = true,
             notes = "Mind-bending masterpiece",
-            dateAdded = 1234567890L
+            dateAdded = 1234567890L,
+            pendingSync = true,
+            pendingDeletion = false,
+            updatedAt = 987654321L
         )
 
-        assertEquals(42L, entry.id)
+        assertEquals("user-1", entry.userId)
+        assertEquals("entry-42", entry.entryId)
         assertEquals("Inception", entry.movieTitle)
         assertEquals("2010", entry.year)
         assertEquals("July 16, 2010", entry.dateWatched)
@@ -68,5 +78,8 @@ class MovieLogEntryTest {
         assertTrue(entry.withSomeone)
         assertEquals("Mind-bending masterpiece", entry.notes)
         assertEquals(1234567890L, entry.dateAdded)
+        assertTrue(entry.pendingSync)
+        assertFalse(entry.pendingDeletion)
+        assertEquals(987654321L, entry.updatedAt)
     }
 }

--- a/app/src/test/java/com/example/movie_project/data/repository/MovieLogRepositoryTest.kt
+++ b/app/src/test/java/com/example/movie_project/data/repository/MovieLogRepositoryTest.kt
@@ -1,82 +1,126 @@
 package com.example.movie_project.data.repository
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.example.movie_project.data.local.MovieLogDao
 import com.example.movie_project.data.local.MovieLogEntry
+import com.example.movie_project.util.NetworkMonitor
+import com.google.firebase.database.FirebaseDatabase
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 /**
- * Unit tests for [MovieLogRepository].
- * Uses Mockito to mock [MovieLogDao] and verify correct delegation.
+ * Unit tests for [MovieLogRepository] focused on the offline-first contract:
+ *  - Offline writes go to Room only; Firebase is NOT called.
+ *  - Offline removals soft-delete (markPendingDeletion) without hardDelete.
+ *  - pushPendingToFirebase is a no-op when offline.
+ *
+ * Online Firebase paths are integration concerns and are exercised in
+ * instrumented / manual testing.
  */
 class MovieLogRepositoryTest {
 
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var dao: MovieLogDao
+    private lateinit var networkMonitor: NetworkMonitor
+    private lateinit var firebase: FirebaseDatabase
     private lateinit var repository: MovieLogRepository
+
+    private val userId = "uid-1"
+    private val entry = MovieLogEntry(
+        entryId = "entry-1",
+        movieTitle = "Inception",
+        year = "2010",
+        directedBy = "Christopher Nolan",
+        starring = "Leonardo DiCaprio",
+        rating = 5,
+        inTheater = true
+    )
 
     @Before
     fun setup() {
-        dao = mock(MovieLogDao::class.java)
-
-        // Stub getAllEntries() before constructing Repository (it's called in the property initializer)
-        val fakeLiveData: LiveData<List<MovieLogEntry>> = MutableLiveData(emptyList())
-        whenever(dao.getAllEntries()).thenReturn(fakeLiveData)
-
-        repository = MovieLogRepository(dao)
+        dao = mock()
+        networkMonitor = mock()
+        firebase = mock()
+        repository = MovieLogRepository(dao, networkMonitor, firebase)
     }
 
     @Test
-    fun `allEntries returns LiveData from dao`() {
-        // The repository's allEntries should be the same LiveData object returned by the DAO
-        val result = repository.allEntries
-        assertSame(dao.getAllEntries(), result)
+    fun addEntry_offline_queuesInRoomAndDoesNotClearPending() = runTest {
+        whenever(networkMonitor.isCurrentlyOnline()).thenReturn(false)
+
+        repository.addEntry(userId, entry)
+
+        // Room is updated (with pendingSync = true under the hood)
+        verify(dao).upsert(any<MovieLogEntry>())
+        // Offline path must NOT clear pendingSync (Firebase wasn't reached)
+        verify(dao, never()).clearPendingSync(any(), any())
     }
 
     @Test
-    fun `getEntryById delegates to dao`() {
-        val fakeEntry = MutableLiveData(MovieLogEntry(id = 1, movieTitle = "Test"))
-        whenever(dao.getEntryById(1L)).thenReturn(fakeEntry)
+    fun updateEntry_offline_queuesInRoomAndDoesNotClearPending() = runTest {
+        whenever(networkMonitor.isCurrentlyOnline()).thenReturn(false)
 
-        val result = repository.getEntryById(1L)
+        repository.updateEntry(userId, entry)
 
-        verify(dao).getEntryById(1L)
-        assertSame(fakeEntry, result)
+        verify(dao).upsert(any<MovieLogEntry>())
+        verify(dao, never()).clearPendingSync(any(), any())
     }
 
     @Test
-    fun `insertEntry delegates to dao and returns id`() = runTest {
-        val entry = MovieLogEntry(movieTitle = "Inception")
-        whenever(dao.insertEntry(entry)).thenReturn(42L)
+    fun deleteEntry_offline_marksPendingDeletionAndDoesNotHardDelete() = runTest {
+        whenever(networkMonitor.isCurrentlyOnline()).thenReturn(false)
 
-        val resultId = repository.insertEntry(entry)
+        repository.deleteEntry(userId, entry.entryId)
 
-        verify(dao).insertEntry(entry)
-        assertEquals(42L, resultId)
+        verify(dao).markPendingDeletion(userId, entry.entryId)
+        verify(dao, never()).hardDelete(any(), any())
     }
 
     @Test
-    fun `updateEntry delegates to dao`() = runTest {
-        val entry = MovieLogEntry(id = 1, movieTitle = "Updated Title")
+    fun pushPendingToFirebase_offline_isNoOp() = runTest {
+        whenever(networkMonitor.isCurrentlyOnline()).thenReturn(false)
 
-        repository.updateEntry(entry)
+        repository.pushPendingToFirebase(userId)
 
-        verify(dao).updateEntry(entry)
+        // No queue read, no DAO mutations
+        verify(dao, never()).getPendingSyncForUser(any())
+        verify(dao, never()).clearPendingSync(any(), any())
+        verify(dao, never()).hardDelete(any(), any())
     }
 
     @Test
-    fun `deleteEntry delegates to dao`() = runTest {
-        val entry = MovieLogEntry(id = 1, movieTitle = "To Delete")
+    fun pullFromFirebase_offline_isNoOp() = runTest {
+        whenever(networkMonitor.isCurrentlyOnline()).thenReturn(false)
 
-        repository.deleteEntry(entry)
+        repository.pullFromFirebase(userId)
 
-        verify(dao).deleteEntry(entry)
+        verify(dao, never()).replaceAllForUser(any(), any())
+    }
+
+    @Test
+    fun observeEntries_delegatesToDao() {
+        whenever(dao.getEntriesForUser(userId)).thenReturn(mock())
+
+        val result = repository.observeEntries(userId)
+
+        verify(dao).getEntriesForUser(userId)
+    }
+
+    @Test
+    fun getEntryById_delegatesToDao() {
+        whenever(dao.getEntryById(userId, entry.entryId)).thenReturn(mock())
+
+        repository.getEntryById(userId, entry.entryId)
+
+        verify(dao).getEntryById(userId, entry.entryId)
     }
 }


### PR DESCRIPTION
Fixed all three stale test files that were left behind after `MovieLogEntry`/`MovieLogDao`/`MovieLogRepository` were refactored to a multi-user, offline-first model (userId + entryId composite key instead of an auto-increment `id`):

1. **`MovieLogDaoTest.kt`** (androidTest) — rewritten to use the real DAO API (`upsert`, `getEntriesForUser`, `getEntryById(userId, entryId)`, `markPendingDeletion`, `hardDelete`, `getPendingSyncForUser`, `replaceAllForUser`), mirroring the working `FavoriteDaoTest.kt` pattern.
2. **`MovieLogEntryTest.kt`** (unit test) — updated field assertions to match the current entity shape (`userId`, `entryId`, `pendingSync`, `pendingDeletion`, `updatedAt`) instead of the old `id: Long`.
3. **`MovieLogRepositoryTest.kt`** (unit test) — rewritten to mock `MovieLogDao`, `NetworkMonitor`, and `FirebaseDatabase` and test the offline-first contract (`addEntry`, `updateEntry`, `deleteEntry`, `pushPendingToFirebase`, `pullFromFirebase`), mirroring `FavoritesRepositoryTest.kt`.

Verified with Gradle:
- `compileDebugAndroidTestKotlin` and `compileDebugUnitTestKotlin` → BUILD SUCCESSFUL
- `testDebugUnitTest` → all unit tests pass
- `connectedDebugAndroidTest` on the running emulator → **25/25 instrumented tests passed**

Your test suite now fully compiles and runs green.