### PR TITLE
add gradle dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,9 @@ plugins {
     id("androidx.navigation.safeargs.kotlin")
     id("kotlin-parcelize")
     id 'org.jetbrains.kotlin.plugin.compose'
+    id("com.google.dagger.hilt.android")
 }
+
 
 android {
     namespace 'com.example.movie_project'
@@ -135,4 +137,11 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
+
+    // Hilt dependency injection
+    implementation "com.google.dagger:hilt-android:2.57.1"
+    kapt "com.google.dagger:hilt-android-compiler:2.57.1"
+    implementation "androidx.hilt:hilt-navigation-fragment:1.2.0"
+    implementation "androidx.hilt:hilt-navigation-compose:1.2.0"
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -15,4 +15,8 @@ plugins {
 
     // The google-services plugin is required to parse the google-services.json file
     id("com.google.gms.google-services") version "4.4.4" apply false
+
+    // Hilt dependency injection
+    id("com.google.dagger.hilt.android") version "2.57.1" apply false
 }
+


### PR DESCRIPTION
the Hilt Gradle plugin (`com.google.dagger.hilt.android` v2.57.1) is now applied at both the root (`build.gradle`, classpath declaration) and app module (`app/build.gradle`, plugin application) level, and the required runtime/compiler dependencies were added (`hilt-android`, `hilt-android-compiler` via kapt, `hilt-navigation-fragment`, `hilt-navigation-compose`). Verified with `./gradlew :app:assembleDebug` — build succeeds and Hilt's annotation processing tasks (`hiltAggregateDepsDebug`, `hiltJavaCompileDebug`) run cleanly alongside the existing Room kapt setup, with no code changes yet (no `@HiltAndroidApp`/`@AndroidEntryPoint`/modules added), so the app behavior is unchanged.

Next up (when you're ready to continue): create the `di/` package with `NetworkModule`, `DatabaseModule`, and `FirebaseModule`, then wire `@Inject`/`@Singleton` into the repositories and convert `MovieMagicApp`, the ViewModels, and the Activities/Fragments.
