### PR TITLE
Phase 1 — Auth abstraction & DI fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,8 @@ dependencies {
 
     // Google Sign In SDK
     implementation("com.google.android.gms:play-services-auth:21.5.1")
+    // Coroutines interop for Play Services / Firebase Tasks (Task.await())
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
 
     // Firebase SDK
     implementation(platform("com.google.firebase:firebase-bom:34.12.0"))

--- a/app/src/main/java/com/example/movie_project/data/local/Migrations.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/Migrations.kt
@@ -42,15 +42,11 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
  */
 val MIGRATION_2_3 = object : Migration(2, 3) {
     override fun migrate(db: SupportSQLiteDatabase) {
-        // Get current user ID from Firebase Auth
-        // Note: During migration, if no user is logged in, entries will be assigned to "unknown"
-        // and can be reassigned later when user logs in
-        val currentUserId = try {
-            com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid ?: "unknown"
-        } catch (e: Exception) {
-            "unknown"
-        }
-        
+        // A schema migration has no auth context, so existing entries are stamped with a
+        // sentinel userId and reassigned to the real user after they next log in
+        // (see MovieLogDao.reassignOrphanedEntries, called from MovieLogRepository).
+        val currentUserId = "unknown"
+
         // Create new table with updated schema
         db.execSQL(
             """

--- a/app/src/main/java/com/example/movie_project/data/local/MovieLogDao.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/MovieLogDao.kt
@@ -65,6 +65,13 @@ interface MovieLogDao {
     suspend fun clearForUser(userId: String)
 
     /**
+     * Reassigns entries stranded under the "unknown" sentinel (from an offline
+     * MIGRATION_2_3) to the now-known user. Idempotent; a no-op once adopted.
+     */
+    @Query("UPDATE movie_log SET userId = :userId WHERE userId = 'unknown'")
+    suspend fun reassignOrphanedEntries(userId: String)
+
+    /**
      * Returns snapshot of all entries for a user (used in conflict resolution).
      */
     @Query("SELECT * FROM movie_log WHERE userId = :userId AND pendingDeletion = 0")

--- a/app/src/main/java/com/example/movie_project/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/movie_project/data/repository/AuthRepository.kt
@@ -1,0 +1,64 @@
+package com.example.movie_project.data.repository
+
+import com.example.movie_project.models.domain.UsersModel
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.GoogleAuthProvider
+import com.google.firebase.database.FirebaseDatabase
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Single entry point for authentication + the current user's identity.
+ *
+ * Wraps the FirebaseAuth / FirebaseDatabase singletons provided by
+ * [com.example.movie_project.di.FirebaseModule] so the rest of the app never
+ * calls FirebaseAuth.getInstance() directly.
+ */
+@Singleton
+class AuthRepository @Inject constructor(
+    private val auth: FirebaseAuth,
+    private val database: FirebaseDatabase
+) {
+
+    val currentUserId: String? get() = auth.currentUser?.uid
+    val currentUserEmail: String? get() = auth.currentUser?.email
+    val isSignedIn: Boolean get() = auth.currentUser != null
+
+    /**
+     * Emits the current user's uid (or null when signed out) on every auth state
+     * change, starting with the current value.
+     */
+    fun authState(): Flow<String?> = callbackFlow {
+        val listener = FirebaseAuth.AuthStateListener { firebaseAuth ->
+            trySend(firebaseAuth.currentUser?.uid)
+        }
+        auth.addAuthStateListener(listener)
+        awaitClose { auth.removeAuthStateListener(listener) }
+    }
+
+    suspend fun login(email: String, password: String): Result<Unit> = runCatching {
+        auth.signInWithEmailAndPassword(email, password).await()
+        Unit
+    }
+
+    suspend fun signUp(email: String, password: String): Result<Unit> = runCatching {
+        auth.createUserWithEmailAndPassword(email, password).await()
+        val uid = auth.currentUser?.uid ?: ""
+        // NOTE: writes to users/user/{uid}; UsersRepository reads that same node.
+        database.reference.child("users").child("user").child(uid)
+            .setValue(UsersModel(email, uid)).await()
+        Unit
+    }
+
+    suspend fun signInWithGoogle(idToken: String): Result<Unit> = runCatching {
+        val credential = GoogleAuthProvider.getCredential(idToken, null)
+        auth.signInWithCredential(credential).await()
+        Unit
+    }
+
+    fun signOut() = auth.signOut()
+}

--- a/app/src/main/java/com/example/movie_project/data/repository/MovieLogRepository.kt
+++ b/app/src/main/java/com/example/movie_project/data/repository/MovieLogRepository.kt
@@ -189,6 +189,16 @@ class MovieLogRepository @Inject constructor(
 
         stopFirebaseListener()
         listeningForUserId = userId
+
+        // Adopt any entries left under the "unknown" sentinel by an offline MIGRATION_2_3.
+        scope.launch {
+            try {
+                movieLogDao.reassignOrphanedEntries(userId)
+            } catch (e: Exception) {
+                Log.w(TAG, "reassignOrphanedEntries failed", e)
+            }
+        }
+
         firebaseRef = database.reference.child("movieLog").child(userId)
 
         firebaseListener = object : ValueEventListener {

--- a/app/src/main/java/com/example/movie_project/data/repository/UsersRepository.kt
+++ b/app/src/main/java/com/example/movie_project/data/repository/UsersRepository.kt
@@ -16,7 +16,7 @@ class UsersRepository @Inject constructor(
     private val database: FirebaseDatabase
 ) {
     fun observeUsers(): Flow<List<UsersModel>> = callbackFlow {
-        val ref = database.reference.child("users")
+        val ref = database.reference.child("users").child("user")
         val listener = object : ValueEventListener {
             override fun onDataChange(snapshot: DataSnapshot) {
                 val list = mutableListOf<UsersModel>()

--- a/app/src/main/java/com/example/movie_project/views/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/FavoritesViewModel.kt
@@ -3,13 +3,14 @@ package com.example.movie_project.views
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
+import com.example.movie_project.data.repository.AuthRepository
 import com.example.movie_project.data.repository.FavoritesRepository
 import com.example.movie_project.models.domain.MovieModel
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,29 +23,40 @@ data class FavoritesUiState(
 
 @HiltViewModel
 class FavoritesViewModel @Inject constructor(
-    private val repository: FavoritesRepository
+    private val repository: FavoritesRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FavoritesUiState(isLoading = true))
     val uiState: StateFlow<FavoritesUiState> = _uiState.asStateFlow()
 
     init {
-        val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
-
-        if (currentUserId != null) {
-            viewModelScope.launch {
-                repository.observeFavorites(currentUserId).collect { list ->
+        // Re-observe whenever the signed-in user changes so switching accounts
+        // never shows the previous user's favorites.
+        viewModelScope.launch {
+            authRepository.authState().collectLatest { uid ->
+                if (uid == null) {
+                    repository.stopFirebaseListener()
+                    _uiState.update {
+                        it.copy(
+                            favorites = emptyList(),
+                            isLoading = false,
+                            errorMessage = "Please sign in to view favorites"
+                        )
+                    }
+                    return@collectLatest
+                }
+                _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                repository.startFirebaseListener(uid)
+                repository.observeFavorites(uid).collect { list ->
                     _uiState.update { it.copy(favorites = list, isLoading = false) }
                 }
             }
-            viewModelScope.launch {
-                repository.errorMessage.asFlow().collect { msg ->
-                    if (!msg.isNullOrEmpty()) _uiState.update { it.copy(errorMessage = msg) }
-                }
+        }
+        viewModelScope.launch {
+            repository.errorMessage.asFlow().collect { msg ->
+                if (!msg.isNullOrEmpty()) _uiState.update { it.copy(errorMessage = msg) }
             }
-            repository.startFirebaseListener(currentUserId)
-        } else {
-            _uiState.update { it.copy(isLoading = false, errorMessage = "Please sign in to view favorites") }
         }
     }
 }

--- a/app/src/main/java/com/example/movie_project/views/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/auth/LoginViewModel.kt
@@ -1,12 +1,14 @@
 package com.example.movie_project.views.auth
 
 import androidx.lifecycle.ViewModel
-import com.google.firebase.auth.FirebaseAuth
+import androidx.lifecycle.viewModelScope
+import com.example.movie_project.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class LoginUiState(
@@ -18,12 +20,12 @@ data class LoginUiState(
 )
 
 @HiltViewModel
-class LoginViewModel @Inject constructor() : ViewModel() {
+class LoginViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
-
-    private val auth = FirebaseAuth.getInstance()
 
     fun onEmailChange(email: String) = _uiState.update { it.copy(email = email) }
     fun onPasswordChange(password: String) = _uiState.update { it.copy(password = password) }
@@ -35,19 +37,18 @@ class LoginViewModel @Inject constructor() : ViewModel() {
             return
         }
         _uiState.update { it.copy(isLoading = true, error = null) }
-        auth.signInWithEmailAndPassword(state.email, state.password)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    _uiState.update { it.copy(isLoading = false, navigateToMain = true) }
-                } else {
+        viewModelScope.launch {
+            authRepository.login(state.email, state.password)
+                .onSuccess { _uiState.update { it.copy(isLoading = false, navigateToMain = true) } }
+                .onFailure { e ->
                     _uiState.update {
-                        it.copy(isLoading = false, error = task.exception?.localizedMessage ?: "Login failed. Please try again.")
+                        it.copy(isLoading = false, error = e.localizedMessage ?: "Login failed. Please try again.")
                     }
                 }
-            }
+        }
     }
 
     fun onNavigatedToMain() = _uiState.update { it.copy(navigateToMain = false) }
 
-    fun isAlreadySignedIn(): Boolean = auth.currentUser != null
+    fun isAlreadySignedIn(): Boolean = authRepository.isSignedIn
 }

--- a/app/src/main/java/com/example/movie_project/views/auth/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/auth/SignUpViewModel.kt
@@ -1,15 +1,14 @@
 package com.example.movie_project.views.auth
 
 import androidx.lifecycle.ViewModel
-import com.example.movie_project.models.domain.UsersModel
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.GoogleAuthProvider
-import com.google.firebase.database.FirebaseDatabase
+import androidx.lifecycle.viewModelScope
+import com.example.movie_project.data.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class SignUpUiState(
@@ -22,12 +21,12 @@ data class SignUpUiState(
 )
 
 @HiltViewModel
-class SignUpViewModel @Inject constructor() : ViewModel() {
+class SignUpViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SignUpUiState())
     val uiState: StateFlow<SignUpUiState> = _uiState.asStateFlow()
-
-    private val auth = FirebaseAuth.getInstance()
 
     fun onEmailChange(email: String) = _uiState.update { it.copy(email = email) }
     fun onPasswordChange(password: String) = _uiState.update { it.copy(password = password) }
@@ -44,34 +43,28 @@ class SignUpViewModel @Inject constructor() : ViewModel() {
             return
         }
         _uiState.update { it.copy(isLoading = true, error = null) }
-        auth.createUserWithEmailAndPassword(state.email, state.password)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    val uid = auth.uid ?: ""
-                    FirebaseDatabase.getInstance().getReference("users")
-                        .child("user").child(uid).setValue(UsersModel(state.email, uid))
-                    _uiState.update { it.copy(isLoading = false, navigateToMain = true) }
-                } else {
+        viewModelScope.launch {
+            authRepository.signUp(state.email, state.password)
+                .onSuccess { _uiState.update { it.copy(isLoading = false, navigateToMain = true) } }
+                .onFailure { e ->
                     _uiState.update {
-                        it.copy(isLoading = false, error = task.exception?.localizedMessage ?: "Sign up failed. Please try again.")
+                        it.copy(isLoading = false, error = e.localizedMessage ?: "Sign up failed. Please try again.")
                     }
                 }
-            }
+        }
     }
 
     fun signInWithGoogle(idToken: String) {
         _uiState.update { it.copy(isLoading = true, error = null) }
-        val credential = GoogleAuthProvider.getCredential(idToken, null)
-        auth.signInWithCredential(credential)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    _uiState.update { it.copy(isLoading = false, navigateToMain = true) }
-                } else {
+        viewModelScope.launch {
+            authRepository.signInWithGoogle(idToken)
+                .onSuccess { _uiState.update { it.copy(isLoading = false, navigateToMain = true) } }
+                .onFailure { e ->
                     _uiState.update {
-                        it.copy(isLoading = false, error = task.exception?.localizedMessage ?: "Google sign-in failed. Please try again.")
+                        it.copy(isLoading = false, error = e.localizedMessage ?: "Google sign-in failed. Please try again.")
                     }
                 }
-            }
+        }
     }
 
     fun onNavigatedToMain() = _uiState.update { it.copy(navigateToMain = false) }

--- a/app/src/main/java/com/example/movie_project/views/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/detail/DetailViewModel.kt
@@ -2,9 +2,9 @@ package com.example.movie_project.views.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.movie_project.data.repository.AuthRepository
 import com.example.movie_project.data.repository.FavoritesRepository
 import com.example.movie_project.models.domain.MovieModel
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,7 +22,8 @@ data class DetailUiState(
 
 @HiltViewModel
 class DetailViewModel @Inject constructor(
-    private val favoritesRepository: FavoritesRepository
+    private val favoritesRepository: FavoritesRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DetailUiState())
@@ -30,7 +31,7 @@ class DetailViewModel @Inject constructor(
 
     fun loadMovie(movie: MovieModel) {
         _uiState.update { it.copy(movie = movie) }
-        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        val uid = authRepository.currentUserId ?: return
         viewModelScope.launch {
             favoritesRepository.isFavorite(uid, movie.id).collect { fav ->
                 _uiState.update { it.copy(isFavorite = fav) }
@@ -39,7 +40,7 @@ class DetailViewModel @Inject constructor(
     }
 
     fun toggleFavorite() {
-        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        val uid = authRepository.currentUserId ?: return
         val movie = _uiState.value.movie ?: return
         val isFav = _uiState.value.isFavorite
         viewModelScope.launch {

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogDetailViewModel.kt
@@ -4,8 +4,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.movie_project.data.local.MovieLogEntry
+import com.example.movie_project.data.repository.AuthRepository
 import com.example.movie_project.data.repository.MovieLogRepository
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,7 +30,8 @@ sealed interface MovieLogDetailEvent {
 
 @HiltViewModel
 class MovieLogDetailViewModel @Inject constructor(
-    private val repository: MovieLogRepository
+    private val repository: MovieLogRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MovieLogDetailUiState())
@@ -40,7 +41,7 @@ class MovieLogDetailViewModel @Inject constructor(
     val events: SharedFlow<MovieLogDetailEvent> = _events.asSharedFlow()
 
     private val userId: String?
-        get() = FirebaseAuth.getInstance().currentUser?.uid
+        get() = authRepository.currentUserId
 
     fun loadEntry(entryId: String) {
         val uid = userId ?: run {

--- a/app/src/main/java/com/example/movie_project/views/movielog/MovieLogViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/movielog/MovieLogViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
 import com.example.movie_project.data.local.MovieLogEntry
+import com.example.movie_project.data.repository.AuthRepository
 import com.example.movie_project.data.repository.MovieLogRepository
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,14 +22,15 @@ data class MovieLogUiState(
 
 @HiltViewModel
 class MovieLogViewModel @Inject constructor(
-    private val repository: MovieLogRepository
+    private val repository: MovieLogRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MovieLogUiState(isLoading = true))
     val uiState: StateFlow<MovieLogUiState> = _uiState.asStateFlow()
 
     init {
-        val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
+        val currentUserId = authRepository.currentUserId
 
         if (currentUserId != null) {
             viewModelScope.launch {

--- a/app/src/main/java/com/example/movie_project/views/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/profile/ProfileViewModel.kt
@@ -2,8 +2,8 @@ package com.example.movie_project.views.profile
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.movie_project.data.repository.AuthRepository
 import com.example.movie_project.data.repository.FavoritesRepository
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,19 +21,19 @@ data class ProfileUiState(
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
-    private val favoritesRepository: FavoritesRepository
+    private val favoritesRepository: FavoritesRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
     init {
-        _uiState.update { it.copy(userEmail = FirebaseAuth.getInstance().currentUser?.email) }
+        _uiState.update { it.copy(userEmail = authRepository.currentUserEmail) }
     }
 
     fun signOut() {
-        val auth = FirebaseAuth.getInstance()
-        val uid = auth.currentUser?.uid
+        val uid = authRepository.currentUserId
         _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             try {
@@ -43,7 +43,7 @@ class ProfileViewModel @Inject constructor(
                     favoritesRepository.clearLocalForUser(uid)
                 }
             } finally {
-                auth.signOut()
+                authRepository.signOut()
                 _uiState.update { it.copy(isLoading = false, navigateToLogin = true) }
             }
         }

--- a/app/src/main/java/com/example/movie_project/views/users/UsersViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/users/UsersViewModel.kt
@@ -2,9 +2,9 @@ package com.example.movie_project.views.users
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.movie_project.data.repository.AuthRepository
 import com.example.movie_project.data.repository.UsersRepository
 import com.example.movie_project.models.domain.UsersModel
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -21,12 +21,13 @@ data class UsersUiState(
 
 @HiltViewModel
 class UsersViewModel @Inject constructor(
-    private val repository: UsersRepository
+    private val repository: UsersRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     val uiState: StateFlow<UsersUiState> = repository.observeUsers()
         .map { allUsers ->
-            val currentUid = FirebaseAuth.getInstance().currentUser?.uid
+            val currentUid = authRepository.currentUserId
             UsersUiState(
                 users = allUsers.filter { it.uid != currentUid },
                 isLoading = false

--- a/app/src/test/java/com/example/movie_project/MainDispatcherRule.kt
+++ b/app/src/test/java/com/example/movie_project/MainDispatcherRule.kt
@@ -1,0 +1,22 @@
+package com.example.movie_project
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * Swaps Dispatchers.Main for a test dispatcher so ViewModels that launch into
+ * viewModelScope can be exercised in plain JVM unit tests.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) = Dispatchers.setMain(dispatcher)
+    override fun finished(description: Description) = Dispatchers.resetMain()
+}

--- a/app/src/test/java/com/example/movie_project/views/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/example/movie_project/views/auth/LoginViewModelTest.kt
@@ -1,0 +1,69 @@
+package com.example.movie_project.views.auth
+
+import com.example.movie_project.MainDispatcherRule
+import com.example.movie_project.data.repository.AuthRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class LoginViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var viewModel: LoginViewModel
+
+    @Before
+    fun setup() {
+        authRepository = mock()
+        viewModel = LoginViewModel(authRepository)
+    }
+
+    @Test
+    fun login_emptyFields_setsErrorAndDoesNotCallRepository() = runTest {
+        viewModel.login()
+
+        assertEquals("Email and password are required", viewModel.uiState.value.error)
+        verify(authRepository, never()).login(any(), any())
+    }
+
+    @Test
+    fun login_success_navigatesToMain() = runTest {
+        whenever(authRepository.login("a@b.com", "pw")).thenReturn(Result.success(Unit))
+        viewModel.onEmailChange("a@b.com")
+        viewModel.onPasswordChange("pw")
+
+        viewModel.login()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.navigateToMain)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun login_failure_surfacesError() = runTest {
+        whenever(authRepository.login("a@b.com", "pw"))
+            .thenReturn(Result.failure(Exception("Invalid credentials")))
+        viewModel.onEmailChange("a@b.com")
+        viewModel.onPasswordChange("pw")
+
+        viewModel.login()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.navigateToMain)
+        assertFalse(state.isLoading)
+        assertEquals("Invalid credentials", state.error)
+    }
+}

--- a/app/src/test/java/com/example/movie_project/views/auth/SignUpViewModelTest.kt
+++ b/app/src/test/java/com/example/movie_project/views/auth/SignUpViewModelTest.kt
@@ -1,0 +1,83 @@
+package com.example.movie_project.views.auth
+
+import com.example.movie_project.MainDispatcherRule
+import com.example.movie_project.data.repository.AuthRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SignUpViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var viewModel: SignUpViewModel
+
+    @Before
+    fun setup() {
+        authRepository = mock()
+        viewModel = SignUpViewModel(authRepository)
+    }
+
+    @Test
+    fun signUp_emptyFields_setsErrorAndDoesNotCallRepository() = runTest {
+        viewModel.signUp()
+
+        assertEquals("All fields are required", viewModel.uiState.value.error)
+        verify(authRepository, never()).signUp(any(), any())
+    }
+
+    @Test
+    fun signUp_mismatchedPasswords_setsErrorAndDoesNotCallRepository() = runTest {
+        viewModel.onEmailChange("a@b.com")
+        viewModel.onPasswordChange("pw1")
+        viewModel.onConfirmPasswordChange("pw2")
+
+        viewModel.signUp()
+
+        assertEquals("Passwords do not match", viewModel.uiState.value.error)
+        verify(authRepository, never()).signUp(any(), any())
+    }
+
+    @Test
+    fun signUp_success_navigatesToMain() = runTest {
+        whenever(authRepository.signUp("a@b.com", "pw")).thenReturn(Result.success(Unit))
+        viewModel.onEmailChange("a@b.com")
+        viewModel.onPasswordChange("pw")
+        viewModel.onConfirmPasswordChange("pw")
+
+        viewModel.signUp()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.navigateToMain)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun signUp_failure_surfacesError() = runTest {
+        whenever(authRepository.signUp("a@b.com", "pw"))
+            .thenReturn(Result.failure(Exception("Email already in use")))
+        viewModel.onEmailChange("a@b.com")
+        viewModel.onPasswordChange("pw")
+        viewModel.onConfirmPasswordChange("pw")
+
+        viewModel.signUp()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.navigateToMain)
+        assertFalse(state.isLoading)
+        assertEquals("Email already in use", state.error)
+    }
+}


### PR DESCRIPTION
 Phase 1 — Auth Abstraction & DI Fix (complete ✅)                                               
                                                                                                  
  Goal: No FirebaseAuth.getInstance() / FirebaseDatabase.getInstance() calls anywhere outside di/ 
  and MovieMagicApp.                                                                              
                                                                                                  
  Files created                                                                                   
                                                                                                  
  - AuthRepository.kt — single @Singleton wrapper around the DI-provided                          
  FirebaseAuth/FirebaseDatabase. API: currentUserId, currentUserEmail, isSignedIn, authState():   
  Flow<String?>, suspend login()/signUp()/signInWithGoogle() (return Result), signOut(). Uses     
  Task.await() instead of hand-rolled listeners.                                                  
  - MainDispatcherRule.kt (test util) — swaps Dispatchers.Main for tests.                         
  - LoginViewModelTest.kt + SignUpViewModelTest.kt — 7 tests (empty fields, mismatched passwords, 
  success, failure).                                                                              
                                                                                                  
  Files modified                                                                                  
                                                                                                  
  - app/build.gradle — added kotlinx-coroutines-play-services (for Task.await()).                 
  - 8 ViewModels migrated off FirebaseAuth.getInstance():                                         
    - Simple swaps: ProfileViewModel, DetailViewModel, MovieLogViewModel, MovieLogDetailViewModel,
  UsersViewModel                                                                                  
    - LoginViewModel / SignUpViewModel — now viewModelScope.launch folding Result into UI state;  
  the Firebase DB write moved out of SignUpViewModel into AuthRepository                          
    - FavoritesViewModel — collects authState() + collectLatest (fixes stale-favorites bug on     
  account switch)                                                                                 
  - UsersRepository.kt — reader now reads users/user to match the write path (bug fix)            
  - Migrations.kt — MIGRATION_2_3 no longer calls Firebase; stamps "unknown" sentinel             
  - MovieLogDao.kt — added reassignOrphanedEntries(userId)                                        
  - MovieLogRepository.kt — calls reassignOrphanedEntries in startFirebaseListener (adopts        
  orphaned rows after login)                                                                      
                                                                                                  
  Verification                                                                                    
                                                                                                  
  - ✅ compileDebugKotlin green                                                                    
  - ✅ Full unit suite green (existinng + 7 new tests)                                             
  - ✅ getInstance() now only in di/FirebaseModuule + MovieMagicApp (persistence config)  