### PR TITLE
Step 3.1 — Type-safe route and Step 3.2 — Stop passing the whole movi…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id("androidx.navigation.safeargs.kotlin")
     id("kotlin-parcelize")
     id 'org.jetbrains.kotlin.plugin.compose'
+    id 'org.jetbrains.kotlin.plugin.serialization'
     id("com.google.dagger.hilt.android")
 }
 
@@ -113,6 +114,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:3.0.0'
 
     // Navigation
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
     implementation "androidx.navigation:navigation-fragment-ktx:2.9.7"
     implementation "androidx.navigation:navigation-ui-ktx:2.9.7"
     implementation "androidx.navigation:navigation-compose:2.9.7"

--- a/app/src/main/java/com/example/movie_project/data/local/FavoriteDao.kt
+++ b/app/src/main/java/com/example/movie_project/data/local/FavoriteDao.kt
@@ -33,6 +33,13 @@ interface FavoriteDao {
     fun isFavorite(userId: String, movieId: Int): Flow<Boolean>
 
     /**
+     * Returns a single cached favorite (not pending deletion), or null — used as an
+     * offline fallback for the detail screen.
+     */
+    @Query("SELECT * FROM favorites WHERE userId = :userId AND movieId = :movieId AND pendingDeletion = 0")
+    suspend fun getFavorite(userId: String, movieId: Int): FavoriteEntry?
+
+    /**
      * Insert or replace a favorite entry.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/example/movie_project/data/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/example/movie_project/data/repository/FavoritesRepository.kt
@@ -71,6 +71,10 @@ class FavoritesRepository @Inject constructor(
     fun isFavorite(userId: String, movieId: Int): Flow<Boolean> =
         favoriteDao.isFavorite(userId, movieId)
 
+    /** Cached favorite as a domain model, or null — offline fallback for detail. */
+    suspend fun getFavorite(userId: String, movieId: Int): MovieModel? =
+        favoriteDao.getFavorite(userId, movieId)?.toMovieModel()
+
     // ----- Writes -----
 
     suspend fun addFavorite(userId: String, movie: MovieModel) =

--- a/app/src/main/java/com/example/movie_project/data/repository/MovieRepository.kt
+++ b/app/src/main/java/com/example/movie_project/data/repository/MovieRepository.kt
@@ -2,6 +2,7 @@ package com.example.movie_project.data.repository
 
 import com.example.movie_project.di.IoDispatcher
 import com.example.movie_project.models.domain.MovieModel
+import com.example.movie_project.models.dto.toMovieModel
 import com.example.movie_project.models.dto.toMovieModels
 import com.example.movie_project.networking.MovieService
 import com.example.movie_project.util.ApiKeyProvider
@@ -40,6 +41,22 @@ class MovieRepository @Inject constructor(
                     response.body()?.results?.toMovieModels() ?: emptyList()
                 } else {
                     throw IllegalStateException("Search failed: ${response.code()}")
+                }
+            }
+        }
+
+    /**
+     * Fetch full details for a single movie by id.
+     */
+    suspend fun getMovieDetails(movieId: Int): Result<MovieModel> =
+        withContext(ioDispatcher) {
+            runCatching {
+                val response = movieService.getMovieDetails(movieId, apiKeyProvider())
+                if (response.isSuccessful) {
+                    response.body()?.toMovieModel()
+                        ?: throw IllegalStateException("Empty movie details")
+                } else {
+                    throw IllegalStateException("Failed to load movie: ${response.code()}")
                 }
             }
         }

--- a/app/src/main/java/com/example/movie_project/networking/MovieService.kt
+++ b/app/src/main/java/com/example/movie_project/networking/MovieService.kt
@@ -1,5 +1,6 @@
 package com.example.movie_project.networking
 
+import com.example.movie_project.models.dto.MovieDto
 import com.example.movie_project.models.dto.MovieResponse
 import retrofit2.Response
 import retrofit2.http.GET
@@ -10,6 +11,12 @@ interface MovieService {
 
     @GET("movie/popular")
     suspend fun getPopularMovies(@Query("api_key") apiKey: String?): Response<MovieResponse>
+
+    @GET("movie/{movie_id}")
+    suspend fun getMovieDetails(
+        @Path("movie_id") movieId: Int,
+        @Query("api_key") apiKey: String?
+    ): Response<MovieDto>
 
     @GET("search/movie")
     suspend fun searchMovies(

--- a/app/src/main/java/com/example/movie_project/views/detail/DetailScreen.kt
+++ b/app/src/main/java/com/example/movie_project/views/detail/DetailScreen.kt
@@ -1,7 +1,10 @@
 package com.example.movie_project.views.detail
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -13,16 +16,19 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,24 +52,66 @@ import java.util.Locale
 
 @Composable
 fun DetailRoute(
-    movie: MovieModel,
     onNavigateBack: () -> Unit,
     onProfileClick: () -> Unit,
     viewModel: DetailViewModel = hiltViewModel()
 ) {
-    LaunchedEffect(movie) {
-        viewModel.loadMovie(movie)
-    }
-
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val movie = uiState.movie
 
-    DetailScreen(
-        movie = movie,
-        isFavorite = uiState.isFavorite,
-        onNavigateBack = onNavigateBack,
-        onProfileClick = onProfileClick,
-        onFavoriteToggle = viewModel::toggleFavorite
-    )
+    when {
+        movie != null -> DetailScreen(
+            movie = movie,
+            isFavorite = uiState.isFavorite,
+            onNavigateBack = onNavigateBack,
+            onProfileClick = onProfileClick,
+            onFavoriteToggle = viewModel::toggleFavorite
+        )
+        uiState.error != null -> DetailErrorState(
+            message = uiState.error!!,
+            onRetry = viewModel::load,
+            onNavigateBack = onNavigateBack
+        )
+        else -> DetailLoadingState()
+    }
+}
+
+@Composable
+private fun DetailLoadingState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(color = Iris)
+    }
+}
+
+@Composable
+private fun DetailErrorState(
+    message: String,
+    onRetry: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(text = message, color = DarkGrey)
+        Spacer(modifier = Modifier.size(16.dp))
+        Button(
+            onClick = onRetry,
+            colors = ButtonDefaults.buttonColors(containerColor = Iris)
+        ) {
+            Text("Retry")
+        }
+        Spacer(modifier = Modifier.size(8.dp))
+        TextButton(onClick = onNavigateBack) {
+            Text("Go back", color = Iris)
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/example/movie_project/views/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/example/movie_project/views/detail/DetailViewModel.kt
@@ -1,10 +1,14 @@
 package com.example.movie_project.views.detail
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.example.movie_project.data.repository.AuthRepository
 import com.example.movie_project.data.repository.FavoritesRepository
+import com.example.movie_project.data.repository.MovieRepository
 import com.example.movie_project.models.domain.MovieModel
+import com.example.movie_project.views.navigation.Route
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,15 +26,44 @@ data class DetailUiState(
 
 @HiltViewModel
 class DetailViewModel @Inject constructor(
+    private val movieRepository: MovieRepository,
     private val favoritesRepository: FavoritesRepository,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    private val movieId: Int = savedStateHandle.toRoute<Route.Detail>().movieId
 
     private val _uiState = MutableStateFlow(DetailUiState())
     val uiState: StateFlow<DetailUiState> = _uiState.asStateFlow()
 
-    fun loadMovie(movie: MovieModel) {
-        _uiState.update { it.copy(movie = movie) }
+    init {
+        load()
+    }
+
+    fun load() {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            movieRepository.getMovieDetails(movieId)
+                .onSuccess { movie -> onMovieLoaded(movie) }
+                .onFailure {
+                    // Offline / failure fallback: use the cached favorite if we have one.
+                    val cached = authRepository.currentUserId?.let { uid ->
+                        favoritesRepository.getFavorite(uid, movieId)
+                    }
+                    if (cached != null) {
+                        onMovieLoaded(cached)
+                    } else {
+                        _uiState.update {
+                            it.copy(isLoading = false, error = "Couldn't load this movie. Check your connection and try again.")
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun onMovieLoaded(movie: MovieModel) {
+        _uiState.update { it.copy(movie = movie, isLoading = false, error = null) }
         val uid = authRepository.currentUserId ?: return
         viewModelScope.launch {
             favoritesRepository.isFavorite(uid, movie.id).collect { fav ->

--- a/app/src/main/java/com/example/movie_project/views/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/movie_project/views/navigation/AppNavHost.kt
@@ -13,14 +13,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import androidx.navigation.NavType
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.example.movie_project.R
-import com.example.movie_project.models.domain.MovieModel
 import com.example.movie_project.views.auth.LoginRoute
 import com.example.movie_project.views.auth.SignUpRoute
 import com.example.movie_project.views.detail.DetailRoute
@@ -34,59 +35,59 @@ import com.example.movie_project.views.search.SearchViewModel
 import com.example.movie_project.views.theme.Iris
 import com.example.movie_project.views.users.UsersRoute
 
-private val bottomNavRoutes = setOf(
-    Route.HOME, Route.FAVORITES, Route.SEARCH, Route.MOVIE_LOG
-)
-
 private data class BottomNavItem(
-    val route: String,
+    val route: Route,
     val label: String,
     val selectedIcon: Int,
     val unselectedIcon: Int
 )
 
 private val bottomNavItems = listOf(
-    BottomNavItem(Route.HOME, "Home", R.drawable.filled_home_24, R.drawable.outline_home),
-    BottomNavItem(Route.FAVORITES, "Favorites", R.drawable.baseline_favorite_24, R.drawable.round_favorite_border_24),
-    BottomNavItem(Route.SEARCH, "Search", R.drawable.filled_search_24, R.drawable.outline_search),
-    BottomNavItem(Route.MOVIE_LOG, "Log", R.drawable.filled_book_24, R.drawable.book_24)
+    BottomNavItem(Route.Home, "Home", R.drawable.filled_home_24, R.drawable.outline_home),
+    BottomNavItem(Route.Favorites, "Favorites", R.drawable.baseline_favorite_24, R.drawable.round_favorite_border_24),
+    BottomNavItem(Route.Search, "Search", R.drawable.filled_search_24, R.drawable.outline_search),
+    BottomNavItem(Route.MovieLog, "Log", R.drawable.filled_book_24, R.drawable.book_24)
 )
 
 @Composable
 fun AppNavHost() {
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = backStackEntry?.destination?.route
+    val currentDestination = backStackEntry?.destination
+
+    val showBottomBar = bottomNavItems.any { item ->
+        currentDestination?.hierarchy?.any { it.hasRoute(item.route::class) } == true
+    }
 
     Scaffold(
         bottomBar = {
-            if (currentRoute in bottomNavRoutes) {
-                AppBottomBar(navController = navController, currentRoute = currentRoute)
+            if (showBottomBar) {
+                AppBottomBar(navController = navController, currentDestination = currentDestination)
             }
         }
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = Route.LOGIN,
+            startDestination = Route.Login,
             modifier = Modifier.padding(innerPadding)
         ) {
             // Auth
-            composable(Route.LOGIN) {
+            composable<Route.Login> {
                 LoginRoute(
                     onNavigateToMain = {
-                        navController.navigate(Route.HOME) {
-                            popUpTo(Route.LOGIN) { inclusive = true }
+                        navController.navigate(Route.Home) {
+                            popUpTo(Route.Login) { inclusive = true }
                         }
                     },
-                    onNavigateToSignUp = { navController.navigate(Route.SIGN_UP) }
+                    onNavigateToSignUp = { navController.navigate(Route.SignUp) }
                 )
             }
 
-            composable(Route.SIGN_UP) {
+            composable<Route.SignUp> {
                 SignUpRoute(
                     onNavigateToMain = {
-                        navController.navigate(Route.HOME) {
-                            popUpTo(Route.LOGIN) { inclusive = true }
+                        navController.navigate(Route.Home) {
+                            popUpTo(Route.Login) { inclusive = true }
                         }
                     },
                     onNavigateToLogin = { navController.popBackStack() }
@@ -94,87 +95,59 @@ fun AppNavHost() {
             }
 
             // Bottom nav tabs
-            composable(Route.HOME) {
+            composable<Route.Home> {
                 HomeRoute(
-                    onMovieClick = { movie -> navController.navigate(Route.detail(movie)) },
-                    onProfileClick = { navController.navigate(Route.PROFILE) }
+                    onMovieClick = { movie -> navController.navigate(Route.Detail(movie.id)) },
+                    onProfileClick = { navController.navigate(Route.Profile) }
                 )
             }
 
-            composable(Route.FAVORITES) {
+            composable<Route.Favorites> {
                 FavoritesRoute(
-                    onMovieClick = { movie -> navController.navigate(Route.detail(movie)) },
-                    onProfileClick = { navController.navigate(Route.PROFILE) }
+                    onMovieClick = { movie -> navController.navigate(Route.Detail(movie.id)) },
+                    onProfileClick = { navController.navigate(Route.Profile) }
                 )
             }
 
-            composable(Route.SEARCH) {
+            composable<Route.Search> {
                 val searchViewModel = hiltViewModel<SearchViewModel>()
                 SearchRoute(
                     viewModel = searchViewModel,
-                    onMovieClicked = { movie -> navController.navigate(Route.detail(movie)) },
-                    onProfileClicked = { navController.navigate(Route.PROFILE) }
+                    onMovieClicked = { movie -> navController.navigate(Route.Detail(movie.id)) },
+                    onProfileClicked = { navController.navigate(Route.Profile) }
                 )
             }
 
-            composable(Route.MOVIE_LOG) {
+            composable<Route.MovieLog> {
                 MovieLogRoute(
-                    onAddEntry = { navController.navigate(Route.movieLogDetail()) },
-                    onEntryClick = { entry -> navController.navigate(Route.movieLogDetail(entry.entryId)) }
+                    onAddEntry = { navController.navigate(Route.MovieLogDetail()) },
+                    onEntryClick = { entry -> navController.navigate(Route.MovieLogDetail(entry.entryId)) }
                 )
             }
 
             // Detail screen
-            composable(
-                route = Route.DETAIL,
-                arguments = listOf(
-                    navArgument("movieId") { type = NavType.IntType; defaultValue = 0 },
-                    navArgument("title") { type = NavType.StringType; defaultValue = "" },
-                    navArgument("posterPath") { type = NavType.StringType; defaultValue = "" },
-                    navArgument("overview") { type = NavType.StringType; defaultValue = "" },
-                    navArgument("releaseDate") { type = NavType.StringType; defaultValue = "" },
-                    navArgument("voteAverage") { type = NavType.FloatType; defaultValue = 0f }
-                )
-            ) { backStackEntry ->
-                val args = backStackEntry.arguments
-                val movie = MovieModel(
-                    id = args?.getInt("movieId") ?: 0,
-                    title = args?.getString("title"),
-                    posterPath = args?.getString("posterPath"),
-                    overview = args?.getString("overview"),
-                    releaseDate = args?.getString("releaseDate"),
-                    voteAverage = args?.getFloat("voteAverage")
-                )
+            composable<Route.Detail> {
                 DetailRoute(
-                    movie = movie,
                     onNavigateBack = { navController.popBackStack() },
-                    onProfileClick = { navController.navigate(Route.PROFILE) }
+                    onProfileClick = { navController.navigate(Route.Profile) }
                 )
             }
 
             // Movie Log Detail (add or edit)
-            composable(
-                route = Route.MOVIE_LOG_DETAIL,
-                arguments = listOf(
-                    navArgument("entryId") {
-                        type = NavType.StringType
-                        nullable = true
-                        defaultValue = null
-                    }
-                )
-            ) { backStackEntry ->
+            composable<Route.MovieLogDetail> { backStackEntry ->
+                val args = backStackEntry.toRoute<Route.MovieLogDetail>()
                 MovieLogDetailRoute(
-                    entryId = backStackEntry.arguments?.getString("entryId"),
+                    entryId = args.entryId,
                     onNavigateBack = { navController.popBackStack() }
                 )
             }
 
             // Profile
-            composable(Route.PROFILE) {
+            composable<Route.Profile> {
                 ProfileRoute(
                     onNavigateBack = { navController.popBackStack() },
                     onSignedOut = {
-                        navController.navigate(Route.LOGIN) {
+                        navController.navigate(Route.Login) {
                             popUpTo(0) { inclusive = true }
                         }
                     }
@@ -182,10 +155,10 @@ fun AppNavHost() {
             }
 
             // Users
-            composable(Route.USERS) {
+            composable<Route.Users> {
                 UsersRoute(
                     onNavigateBack = { navController.popBackStack() },
-                    onProfileClick = { navController.navigate(Route.PROFILE) }
+                    onProfileClick = { navController.navigate(Route.Profile) }
                 )
             }
         }
@@ -193,15 +166,15 @@ fun AppNavHost() {
 }
 
 @Composable
-private fun AppBottomBar(navController: NavController, currentRoute: String?) {
+private fun AppBottomBar(navController: NavController, currentDestination: NavDestination?) {
     NavigationBar {
         bottomNavItems.forEach { item ->
-            val selected = currentRoute == item.route
+            val selected = currentDestination?.hierarchy?.any { it.hasRoute(item.route::class) } == true
             NavigationBarItem(
                 selected = selected,
                 onClick = {
                     navController.navigate(item.route) {
-                        popUpTo(Route.HOME) { saveState = true }
+                        popUpTo(Route.Home) { saveState = true }
                         launchSingleTop = true
                         restoreState = true
                     }

--- a/app/src/main/java/com/example/movie_project/views/navigation/AppRoutes.kt
+++ b/app/src/main/java/com/example/movie_project/views/navigation/AppRoutes.kt
@@ -1,40 +1,29 @@
 package com.example.movie_project.views.navigation
 
-import android.net.Uri
-import com.example.movie_project.models.domain.MovieModel
+import kotlinx.serialization.Serializable
 
-object Route {
-    // Auth
-    const val LOGIN = "login"
-    const val SIGN_UP = "sign_up"
+/**
+ * Type-safe navigation routes. Each destination is a [Serializable] type consumed
+ * by the Navigation-Compose type-safe API (composable<Route.X> / navigate(Route.X)).
+ */
+sealed interface Route {
 
-    // Bottom nav tabs
-    const val HOME = "home"
-    const val FAVORITES = "favorites"
-    const val SEARCH = "search"
-    const val MOVIE_LOG = "movie_log"
+    @Serializable data object Login : Route
+    @Serializable data object SignUp : Route
 
-    // Detail — individual fields encoded as query params
-    const val DETAIL = "detail?movieId={movieId}&title={title}&posterPath={posterPath}&overview={overview}&releaseDate={releaseDate}&voteAverage={voteAverage}"
+    @Serializable data object Home : Route
+    @Serializable data object Favorites : Route
+    @Serializable data object Search : Route
+    @Serializable data object MovieLog : Route
 
-    // MovieLogDetail — entryId is optional (null = new entry)
-    const val MOVIE_LOG_DETAIL = "movie_log_detail?entryId={entryId}"
+    @Serializable data object Profile : Route
+    @Serializable data object Users : Route
 
-    // Top-level screens
-    const val PROFILE = "profile"
-    const val USERS = "users"
+    /** Movie detail. Carries only the id; DetailViewModel loads the rest. */
+    @Serializable
+    data class Detail(val movieId: Int) : Route
 
-    // Builder helpers
-    fun detail(movie: MovieModel) =
-        "detail" +
-        "?movieId=${movie.id}" +
-        "&title=${Uri.encode(movie.title ?: "")}" +
-        "&posterPath=${Uri.encode(movie.posterPath ?: "")}" +
-        "&overview=${Uri.encode(movie.overview ?: "")}" +
-        "&releaseDate=${Uri.encode(movie.releaseDate ?: "")}" +
-        "&voteAverage=${movie.voteAverage ?: 0f}"
-
-    fun movieLogDetail(entryId: String? = null) =
-        if (entryId != null) "movie_log_detail?entryId=$entryId"
-        else "movie_log_detail"
+    /** Movie log entry (null entryId = new entry). */
+    @Serializable
+    data class MovieLogDetail(val entryId: String? = null) : Route
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'com.android.library' version '8.13.2' apply false
     id 'org.jetbrains.kotlin.android' version '2.3.21' apply false
     id 'org.jetbrains.kotlin.plugin.compose' version '2.3.21' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.3.21' apply false
 
     // The google-services plugin is required to parse the google-services.json file
     id("com.google.gms.google-services") version "4.4.4" apply false


### PR DESCRIPTION
Phase 3 — Navigation & auth flow                                                                
                                                                                                  
  Goal: Routes carry IDs, not serialized objects; start destination reflects auth state; one      
  activity.                                                                                       
                                                                                                  
  Step 3.1 — Type-safe routes. Add kotlinx-serialization plugin + navigation's type-safe API (nav 
  2.9.x supports it). Replace the Route object's string constants with @Serializable route classes
  (data object Home, data class Detail(val movieId: Int, ...), data class MovieLogDetail(val      
  entryId: String?)). This deletes Route.detail()'s manual Uri.encode string building and the     
  navArgument blocks in AppNavHost.                                                               
                                                                                                  
  Step 3.2 — Stop passing the whole movie. Detail route carries only movieId. Two options for     
  DetailViewModel to get the data — since favorites already live in Room but arbitrary search     
  results don't, the pragmatic choice: add getMovieDetails(movieId) to                            
  MovieService/MovieRepository (TMDB /movie/{id}) and have DetailViewModel load it via            
  SavedStateHandle, falling back to the Room favorite when offline. This also gets you richer     
  detail data (runtime, genres) for free. (If you'd rather avoid the extra network call for now,  
  keep title/posterPath as route args and fetch the rest — but say so in a TODO;                  
  full-object-in-route shouldn't return.)  